### PR TITLE
Switch to appveyor builds

### DIFF
--- a/AxoCover/AxoCover.csproj
+++ b/AxoCover/AxoCover.csproj
@@ -44,7 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CopyVsixExtensionFiles>False</CopyVsixExtensionFiles>
-    <DeployExtension>False</DeployExtension>
+    <DeployExtension>True</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -56,6 +56,31 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.7.0.4\lib\net20\envdte.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="envdte100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.10.10.0.4\lib\net20\envdte100.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.8.8.0.4\lib\net20\envdte80.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="envdte90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.9.9.0.4\lib\net20\envdte90.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="envdte90a, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.9.9.0.4\lib\net20\envdte90a.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
@@ -73,47 +98,96 @@
       <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.CoreUtility.11.0.4\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Platform.WindowManagement, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\Microsoft.VisualStudio.Platform.WindowManagement.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.GraphModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.GraphModel.11.0.4\lib\net45\Microsoft.VisualStudio.GraphModel.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0">
-      <EmbedInteropTypes>true</EmbedInteropTypes>
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.OLE.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.ViewManager, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\Microsoft.VisualStudio.Shell.ViewManager.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Shell.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Shell.11.11.0.4\lib\net45\Microsoft.VisualStudio.Shell.11.0.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Text.Data.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Shell.Immutable.10.10.0.4\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Shell.Immutable.11.11.0.4\lib\net45\Microsoft.VisualStudio.Shell.Immutable.11.0.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Text.UI.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.Shell.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.Shell.Interop.10.10.0.4\lib\net20\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.11.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.Shell.Interop.11.11.0.4\lib\net20\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.Shell.Interop.8.8.0.4\lib\net20\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.Shell.Interop.9.9.0.4\lib\net20\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Text.11.0.4\lib\net45\Microsoft.VisualStudio.Text.Data.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Text.11.0.4\lib\net45\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Text.11.0.4\lib\net45\Microsoft.VisualStudio.Text.UI.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Text.11.0.4\lib\net45\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.TextManager.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.TextManager.Interop.8.8.0.4\lib\net20\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
+      <Private>True</Private>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="PresentationFramework.Aero" />
+    <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.7.0.4\lib\net20\stdole.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -124,6 +198,7 @@
     <Reference Include="System.Management" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
@@ -134,52 +209,39 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="UIAutomationTypes" />
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.VSLangProj.7.0.4\lib\net20\VSLangProj.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="VSLangProj100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.VSLangProj.10.10.0.4\lib\net20\VSLangProj100.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="VSLangProj110, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.VSLangProj.11.11.0.4\lib\net20\VSLangProj110.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="VSLangProj2, Version=7.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.VSLangProj.7.0.4\lib\net20\VSLangProj2.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="VSLangProj80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.VSLangProj.8.8.0.4\lib\net20\VSLangProj80.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="VSLangProj90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.VSLangProj.9.9.0.4\lib\net20\VSLangProj90.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="System.Xaml" />
-  </ItemGroup>
-  <ItemGroup>
-    <COMReference Include="EnvDTE">
-      <Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE100">
-      <Guid>{26AD1324-4B7C-44BC-84F8-B86AED45729F}</Guid>
-      <VersionMajor>10</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE80">
-      <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE90">
-      <Guid>{2CE2370E-D744-4936-A090-3FFFE667B0E1}</Guid>
-      <VersionMajor>9</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controls\ActionButton.xaml.cs">

--- a/AxoCover/AxoCover.csproj
+++ b/AxoCover/AxoCover.csproj
@@ -54,6 +54,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <DeployExtension>False</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/AxoCover/Models/TestAssemblyScanner.cs
+++ b/AxoCover/Models/TestAssemblyScanner.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -17,19 +16,19 @@ namespace AxoCover.Models
       try
       {
         var assembly = Assembly.LoadFrom(assemblyPath);
-        var testClasses = FilterByAttribute(assembly.ExportedTypes, nameof(TestClassAttribute))
+        var testClasses = FilterByAttribute(assembly.ExportedTypes, "TestClassAttribute")
           .Where(p => !p.IsAbstract);
 
         foreach (var testClass in testClasses)
         {
-          var isClassIgnored = testClass.GetCustomAttributesData().Any(p => p.AttributeType.Name == nameof(IgnoreAttribute));
-          var testMethods = FilterByAttribute(testClass.GetMethods(), nameof(TestMethodAttribute));
+          var isClassIgnored = testClass.GetCustomAttributesData().Any(p => p.AttributeType.Name == "IgnoreAttribute");
+          var testMethods = FilterByAttribute(testClass.GetMethods(), "TestMethodAttribute");
           var testClassName = testClass.FullName;
 
           foreach (var testMethod in testMethods)
           {
             var testMethodName = testClassName + "." + testMethod.Name;
-            var isMethodIgnored = testMethod.GetCustomAttributesData().Any(p => p.AttributeType.Name == nameof(IgnoreAttribute));
+            var isMethodIgnored = testMethod.GetCustomAttributesData().Any(p => p.AttributeType.Name == "IgnoreAttribute");
             if (isClassIgnored || isMethodIgnored)
             {
               testMethodName = IgnorePrefix + testMethodName;

--- a/AxoCover/Resources.Designer.cs
+++ b/AxoCover/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace AxoCover {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Build version is {0}, please reference this in your feedback..
+        /// </summary>
+        public static string AssemblyVersion {
+            get {
+                return ResourceManager.GetString("AssemblyVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cover after each build.
         /// </summary>
         public static string AutoCover {

--- a/AxoCover/Resources.resx
+++ b/AxoCover/Resources.resx
@@ -432,4 +432,7 @@
   <data name="CoverByTestExcludeByTestAssemblyWarning" xml:space="preserve">
     <value>Warning! Excluding test assemblies will prevent cover by test feature from working in those assemblies.</value>
   </data>
+  <data name="AssemblyVersion" xml:space="preserve">
+    <value>Build version is {0}, please reference this in your feedback.</value>
+  </data>
 </root>

--- a/AxoCover/ViewModels/SettingsViewModel.cs
+++ b/AxoCover/ViewModels/SettingsViewModel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -25,6 +26,14 @@ namespace AxoCover.ViewModels
       get
       {
         return AxoCoverPackage.Manifest;
+      }
+    }
+
+    public string AssemblyVersion
+    {
+      get
+      {
+        return Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
       }
     }
 

--- a/AxoCover/Views/SettingsView.xaml
+++ b/AxoCover/Views/SettingsView.xaml
@@ -51,38 +51,36 @@
 
       <!-- About -->
       <Label Content="{x:Static res:Resources.About}" Style="{StaticResource Header}" Margin="-6,0"/>
-      <StackPanel>
-        <DockPanel>
-          <Image DockPanel.Dock="Right" Source="/AxoCover;component/Resources/icon.png" Stretch="Uniform" Margin="3,6,6,6" Width="64" VerticalAlignment="Top"/>
-          <StackPanel VerticalAlignment="Top" Margin="3">
-            <Label>
-              <TextBlock TextWrapping="Wrap">
-                <Run Text="{Binding Manifest.Name, Mode=OneTime}" FontWeight="Bold" FontSize="20px"/>
-                <Run Text="{Binding Manifest.Version, Mode=OneTime}" FontSize="16px"/>
-                <LineBreak/>
-                <Run Text="{Binding Manifest.Description, Mode=OneTime}"/>
-              </TextBlock>
-            </Label>
-            <StackPanel Margin="0,1.5">
-              <StackPanel.Resources>
-                <Style TargetType="controls:ActionButton">
-                  <Setter Property="Icon" Value="/AxoCover;component/Resources/open.png"/>
-                  <Setter Property="HorizontalAlignment" Value="Left"/>
-                  <Setter Property="Margin" Value="0,1.5"/>
-                </Style>
-              </StackPanel.Resources>
-              <controls:ActionButton Text="{x:Static res:Resources.WebSite}" 
-                                     Command="{Binding OpenWebSiteCommand}"/>
-              <controls:ActionButton Text="{x:Static res:Resources.ReleaseNotes}"
-                                     Command="{Binding OpenReleaseNotesDialogCommand}"/>
-              <controls:ActionButton Text="{x:Static res:Resources.SourceCode}"
-                                     Command="{Binding OpenSourceCodeCommand}"/>
-              <controls:ActionButton Text="{x:Static res:Resources.License}"
-                                     Command="{Binding OpenLicenseDialogCommand}"/>
-            </StackPanel>
-          </StackPanel>
-        </DockPanel>
-      </StackPanel>
+      <DockPanel>
+        <Image DockPanel.Dock="Right" Source="/AxoCover;component/Resources/icon.png" Stretch="Uniform" Margin="3,6,6,6" Width="64" VerticalAlignment="Top"/>
+        <StackPanel VerticalAlignment="Top" Margin="3">
+          <Label>
+            <TextBlock TextWrapping="Wrap">
+              <Run Text="{Binding Manifest.Name, Mode=OneTime}" FontWeight="Bold" FontSize="20px"/>
+              <Run Text="{Binding Manifest.Version, Mode=OneTime}" FontSize="16px"/>
+              <LineBreak/>
+              <Run Text="{Binding Manifest.Description, Mode=OneTime}"/>
+            </TextBlock>
+          </Label>
+          <StackPanel Margin="0,1.5">
+            <StackPanel.Resources>
+              <Style TargetType="controls:ActionButton">
+                <Setter Property="Icon" Value="/AxoCover;component/Resources/open.png"/>
+                <Setter Property="HorizontalAlignment" Value="Left"/>
+                <Setter Property="Margin" Value="0,1.5"/>
+              </Style>
+            </StackPanel.Resources>
+            <controls:ActionButton Text="{x:Static res:Resources.WebSite}" 
+                                    Command="{Binding OpenWebSiteCommand}"/>
+            <controls:ActionButton Text="{x:Static res:Resources.ReleaseNotes}"
+                                    Command="{Binding OpenReleaseNotesDialogCommand}"/>
+            <controls:ActionButton Text="{x:Static res:Resources.SourceCode}"
+                                    Command="{Binding OpenSourceCodeCommand}"/>
+            <controls:ActionButton Text="{x:Static res:Resources.License}"
+                                    Command="{Binding OpenLicenseDialogCommand}"/>
+          </StackPanel>          
+        </StackPanel>
+      </DockPanel>
 
       <!-- Feedback settings -->
       <Label Content="{x:Static res:Resources.Feedback}" Style="{StaticResource Header}"/>
@@ -94,12 +92,13 @@
             <Setter Property="HorizontalAlignment" Value="Left"/>
             <Setter Property="Margin" Value="0,1.5"/>
           </Style>
-        </StackPanel.Resources>
+        </StackPanel.Resources>        
         <controls:ActionButton Text="{x:Static res:Resources.OpenIssues}" Command="{Binding OpenIssuesCommand}"/>
         <controls:ActionButton Text="{x:Static res:Resources.SendFeedback}" Command="{Binding SendFeedbackCommand}"/>
       </StackPanel>      
       <TextBlock Text="{x:Static res:Resources.TelemetryDescription}" Style="{StaticResource Description}"/>
-      <CheckBox Content="{x:Static res:Resources.EnableTelemetry}" IsChecked="{Binding IsTelemetryEnabled}" Margin="3"/>      
+      <CheckBox Content="{x:Static res:Resources.EnableTelemetry}" IsChecked="{Binding IsTelemetryEnabled}" Margin="3"/>
+      <TextBlock Text="{Binding AssemblyVersion, StringFormat={x:Static res:Resources.AssemblyVersion}}" Style="{StaticResource Description}"/>
 
       <!-- Visualization settings -->
       <Label Content="{x:Static res:Resources.VisualizationSettings}" Style="{StaticResource Header}"/>

--- a/AxoCover/packages.config
+++ b/AxoCover/packages.config
@@ -4,4 +4,34 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
   <package id="VsixUpdater" version="1.0.25" targetFramework="net45" />
+  <package id="VSSDK.CoreUtility" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.CoreUtility.11" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.DTE" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.DTE.10" version="10.0.4" targetFramework="net45" />
+  <package id="VSSDK.DTE.8" version="8.0.4" targetFramework="net45" />
+  <package id="VSSDK.DTE.9" version="9.0.4" targetFramework="net45" />
+  <package id="VSSDK.GraphModel" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.10" version="10.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.11" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.8" version="8.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.9" version="9.0.4" targetFramework="net45" />
+  <package id="VSSDK.OLE.Interop" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.11" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.Immutable.10" version="10.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.Immutable.11" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.Interop" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.Interop.10" version="10.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.Interop.11" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.Interop.8" version="8.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.Interop.9" version="9.0.4" targetFramework="net45" />
+  <package id="VSSDK.Text" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.Text.11" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.TextManager.Interop" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.TextManager.Interop.8" version="8.0.4" targetFramework="net45" />
+  <package id="VSSDK.VSLangProj" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.VSLangProj.10" version="10.0.4" targetFramework="net45" />
+  <package id="VSSDK.VSLangProj.11" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.VSLangProj.8" version="8.0.4" targetFramework="net45" />
+  <package id="VSSDK.VSLangProj.9" version="9.0.4" targetFramework="net45" />
 </packages>

--- a/AxoCover/source.extension.vsixmanifest
+++ b/AxoCover/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.0.70.0" Language="en-US" Publisher="Péter Major" />
+    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.0.71.0" Language="en-US" Publisher="Péter Major" />
     <DisplayName>AxoCover</DisplayName>
     <Description xml:space="preserve">Nice and free .Net code coverage support for Visual Studio with OpenCover.</Description>
     <MoreInfo>https://marketplace.visualstudio.com/items?itemName=axodox1.AxoCover</MoreInfo>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+version: 1.0.{build}
+skip_tags: true
+configuration: Release
+platform: Any CPU
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+before_build:
+- cmd: nuget restore
+build:
+  project: AxoCover.sln
+  verbosity: minimal
+artifacts:
+- path: AxoCover\bin\Release\AxoCover.vsix
+  name: AxoCover.vsix
+deploy:
+- provider: GitHub
+  tag: ${appveyor_repo_branch}-${appveyor_build_version}
+  auth_token:
+    secure: Vak3FzsaGXTJb/S0Ee3fPOWlHPNi52kz2e7WCLhwAa6pNe4jfKjl5rNEFfcnecI8
+  artifact: AxoCover.vsix
+  prerelease: false


### PR DESCRIPTION
This change is to switch build from VS2012 to VS2015 and use AppVeyor instead of Visual Studio Online. Visual Studio 2012 compatibility is kept by getting the necessary DLLs from NuGet packages.