### PR TITLE
Ms test v2 support

### DIFF
--- a/AxoCover.Common/AxoCover.Common.csproj
+++ b/AxoCover.Common/AxoCover.Common.csproj
@@ -40,14 +40,11 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
@@ -63,6 +60,12 @@
     <Compile Include="Extensions\GenericExtensions.cs" />
     <Compile Include="Extensions\NetworkingExtensions.cs" />
     <Compile Include="Extensions\ProcessHostExtensions.cs" />
+    <Compile Include="Models\TestCase.cs" />
+    <Compile Include="Models\TestMessageLevel.cs" />
+    <Compile Include="Models\TestOutcome.cs" />
+    <Compile Include="Models\TestProperty.cs" />
+    <Compile Include="Models\TestPropertyAttributes.cs" />
+    <Compile Include="Models\TestResult.cs" />
     <Compile Include="ProcessHost\IHostProcessInfo.cs" />
     <Compile Include="ProcessHost\IProcessInfo.cs" />
     <Compile Include="ProcessHost\PlatformProcessInfo.cs" />
@@ -95,6 +98,7 @@
       <Name>AxoCover.Host-x86</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/AxoCover.Common/AxoCover.Common.csproj
+++ b/AxoCover.Common/AxoCover.Common.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Runner\ITestExecutionService.cs" />
     <Compile Include="Runner\ITestExecutionMonitor.cs" />
     <Compile Include="Runner\TestExecutionOptions.cs" />
+    <Compile Include="Settings\TestAdapterMode.cs" />
     <Compile Include="Settings\TestApartmentState.cs" />
     <Compile Include="Settings\TestPlatform.cs" />
   </ItemGroup>

--- a/AxoCover.Common/Models/TestCase.cs
+++ b/AxoCover.Common/Models/TestCase.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace AxoCover.Common.Models
+{
+  [DataContract]
+  public class TestCase
+  {
+    [DataMember]
+    public string CodeFilePath { get; set; }
+
+    [DataMember]
+    public string DisplayName { get; set; }
+
+    [DataMember]
+    public Uri ExecutorUri { get; set; }
+
+    [DataMember]
+    public string FullyQualifiedName { get; set; }
+
+    [DataMember]
+    public Guid Id { get; set; }
+
+    [DataMember]
+    public int LineNumber { get; set; }
+
+    [DataMember]
+    public string Source { get; set; }
+
+    [DataMember]
+    public List<TestProperty> AdditionalProperties { get; set; }
+  }
+}

--- a/AxoCover.Common/Models/TestMessageLevel.cs
+++ b/AxoCover.Common/Models/TestMessageLevel.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.Serialization;
+
+namespace AxoCover.Common.Models
+{
+  [DataContract]
+  public enum TestMessageLevel
+  {
+    [EnumMember]
+    Informational,
+
+    [EnumMember]
+    Warning,
+
+    [EnumMember]
+    Error
+  }
+}

--- a/AxoCover.Common/Models/TestOutcome.cs
+++ b/AxoCover.Common/Models/TestOutcome.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.Serialization;
+
+namespace AxoCover.Common.Models
+{
+  [DataContract]
+  public enum TestOutcome
+  {
+    [EnumMember]
+    None,
+
+    [EnumMember]
+    Passed,
+
+    [EnumMember]
+    Failed,
+
+    [EnumMember]
+    Skipped,
+
+    [EnumMember]
+    NotFound
+  }
+}

--- a/AxoCover.Common/Models/TestProperty.cs
+++ b/AxoCover.Common/Models/TestProperty.cs
@@ -1,0 +1,29 @@
+﻿using System.Runtime.Serialization;
+
+namespace AxoCover.Common.Models
+{
+  [DataContract]
+  public class TestProperty
+  {
+    [DataMember]
+    public TestPropertyAttributes Attributes { get; set; }
+
+    [DataMember]
+    public string Category { get; set; }
+
+    [DataMember]
+    public string Description { get; set; }
+
+    [DataMember]
+    public string Id { get; set; }
+
+    [DataMember]
+    public string Label { get; set; }
+
+    [DataMember]
+    public string ValueType { get; set; }
+
+    [DataMember]
+    public string Value { get; set; }
+  }
+}

--- a/AxoCover.Common/Models/TestPropertyAttributes.cs
+++ b/AxoCover.Common/Models/TestPropertyAttributes.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace AxoCover.Common.Models
+{
+  [DataContract]
+  [Flags]
+  public enum TestPropertyAttributes
+  {
+    [EnumMember]
+    None = 0,
+
+    [EnumMember]
+    Hidden = 1,
+
+    [EnumMember]
+    Immutable = 2,
+
+    [EnumMember]
+    Trait = 4
+  }
+}

--- a/AxoCover.Common/Models/TestResult.cs
+++ b/AxoCover.Common/Models/TestResult.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace AxoCover.Common.Models
+{
+  [DataContract]
+  public class TestResult
+  {
+    [DataMember]
+    public string ComputerName { get; set; }
+
+    [DataMember]
+    public string DisplayName { get; set; }
+
+    [DataMember]
+    public TimeSpan Duration { get; set; }
+
+    [DataMember]
+    public DateTimeOffset EndTime { get; set; }
+
+    [DataMember]
+    public string ErrorMessage { get; set; }
+
+    [DataMember]
+    public string ErrorStackTrace { get; set; }
+
+    [DataMember]
+    public TestOutcome Outcome { get; set; }
+
+    [DataMember]
+    public DateTimeOffset StartTime { get; set; }
+
+    [DataMember]
+    public TestCase TestCase { get; set; }
+  }
+}

--- a/AxoCover.Common/Runner/ITestDiscoveryMonitor.cs
+++ b/AxoCover.Common/Runner/ITestDiscoveryMonitor.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+﻿using AxoCover.Common.Models;
 using System.ServiceModel;
 
 namespace AxoCover.Common.Runner

--- a/AxoCover.Common/Runner/ITestExecutionMonitor.cs
+++ b/AxoCover.Common/Runner/ITestExecutionMonitor.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+﻿using AxoCover.Common.Models;
 using System.ServiceModel;
 
 namespace AxoCover.Common.Runner

--- a/AxoCover.Common/Runner/ITestExecutionService.cs
+++ b/AxoCover.Common/Runner/ITestExecutionService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+﻿using AxoCover.Common.Models;
 using System.Collections.Generic;
 using System.ServiceModel;
 

--- a/AxoCover.Common/Settings/TestAdapterMode.cs
+++ b/AxoCover.Common/Settings/TestAdapterMode.cs
@@ -1,0 +1,8 @@
+﻿namespace AxoCover.Common.Settings
+{
+  public enum TestAdapterMode
+  {
+    Integrated,
+    Standard
+  }
+}

--- a/AxoCover.Common/packages.config
+++ b/AxoCover.Common/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net452" />
 </packages>

--- a/AxoCover.Dependencies/AxoCover.Dependencies.csproj
+++ b/AxoCover.Dependencies/AxoCover.Dependencies.csproj
@@ -39,7 +39,12 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -94,7 +99,6 @@
       <Link>MSTestAdapter\%(Filename)%(Extension)</Link>
     </Content>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/AxoCover.Dependencies/AxoCover.Dependencies.csproj
+++ b/AxoCover.Dependencies/AxoCover.Dependencies.csproj
@@ -97,6 +97,12 @@
     <Content Include="..\packages\MSTest.TestFramework.*\lib\net45\*.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>MSTestAdapter\%(Filename)%(Extension)</Link>
+    </Content>    
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\packages\Microsoft.TestPlatform.ObjectModel.*\lib\net35\*.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>TestPlatform\%(Filename)%(Extension)</Link>
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/AxoCover.Dependencies/packages.config
+++ b/AxoCover.Dependencies/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.1.13" targetFramework="net45" />
-  <package id="MSTest.TestFramework" version="1.1.13" targetFramework="net45" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net45" />
+  <package id="MSTest.TestAdapter" version="1.1.14" targetFramework="net46" />
+  <package id="MSTest.TestFramework" version="1.1.14" targetFramework="net46" />
   <package id="NUnit3TestAdapter.AxoCover" version="1.0.0" targetFramework="net45" />
   <package id="OpenCover.AxoCover" version="1.0.0" targetFramework="net45" />
   <package id="ReportGenerator" version="2.5.6" targetFramework="net45" />

--- a/AxoCover.Host-x64/App.config
+++ b/AxoCover.Host-x64/App.config
@@ -3,12 +3,4 @@
   <startup> 
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
   </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.TestPlatform.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/AxoCover.Host-x64/App.config
+++ b/AxoCover.Host-x64/App.config
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
-    </startup>
+  <startup> 
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.TestPlatform.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/AxoCover.Host-x86/App.config
+++ b/AxoCover.Host-x86/App.config
@@ -3,12 +3,4 @@
   <startup> 
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
   </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.TestPlatform.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/AxoCover.Host-x86/App.config
+++ b/AxoCover.Host-x86/App.config
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
-    </startup>
+  <startup> 
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.TestPlatform.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/AxoCover.Runner/App.config
+++ b/AxoCover.Runner/App.config
@@ -1,6 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup> 
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.TestPlatform.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/AxoCover.Runner/App.config
+++ b/AxoCover.Runner/App.config
@@ -1,14 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup> 
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
   </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.TestPlatform.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/AxoCover.Runner/AxoCover.Runner.csproj
+++ b/AxoCover.Runner/AxoCover.Runner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AxoCover.Runner</RootNamespace>
     <AssemblyName>AxoCover.Runner</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -41,11 +41,10 @@
       <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -54,9 +53,6 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />

--- a/AxoCover.Runner/AxoCover.Runner.csproj
+++ b/AxoCover.Runner/AxoCover.Runner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AxoCover.Runner</RootNamespace>
     <AssemblyName>AxoCover.Runner</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -41,13 +41,23 @@
       <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -57,6 +67,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConversionExtensions.cs" />
     <Compile Include="InvocationBuffer.cs" />
     <Compile Include="Settings\RunConfiguration.cs" />
     <Compile Include="Settings\RunSettings.cs" />
@@ -68,7 +79,9 @@
     <Compile Include="TestExecutionContext.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -77,6 +90,10 @@
     <ProjectReference Include="..\AxoCover.Common\AxoCover.Common.csproj">
       <Project>{2CA98ECF-C250-4524-AD43-749B59E60BC1}</Project>
       <Name>AxoCover.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AxoCover.Dependencies\AxoCover.Dependencies.csproj">
+      <Project>{DE90F6EF-57C2-4963-8639-505F29A3DBBE}</Project>
+      <Name>AxoCover.Dependencies</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/AxoCover.Runner/ConversionExtensions.cs
+++ b/AxoCover.Runner/ConversionExtensions.cs
@@ -1,0 +1,147 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AxoCover.Runner
+{
+  public static class ConversionExtensions
+  {
+    private static readonly HashSet<string> _ignoredTestCaseProperties =
+      new HashSet<string>(typeof(TestCase).GetProperties().Select(p => "TestCase." + p.Name).Concat(new[] { "TestObject.Traits" }));
+
+    private static readonly ConcurrentDictionary<string, Type> _typeCache = new ConcurrentDictionary<string, Type>();
+
+    public static Common.Models.TestMessageLevel Convert(this TestMessageLevel testMessageLevel)
+    {
+      return (Common.Models.TestMessageLevel)testMessageLevel;
+    }
+
+    public static Common.Models.TestCase[] Convert(this IEnumerable<TestCase> testCases)
+    {
+      return testCases.Select(Convert).ToArray();
+    }
+
+    public static Common.Models.TestCase Convert(this TestCase testCase)
+    {
+      return new Common.Models.TestCase()
+      {
+        CodeFilePath = testCase.CodeFilePath,
+        DisplayName = testCase.DisplayName,
+        ExecutorUri = testCase.ExecutorUri,
+        FullyQualifiedName = testCase.FullyQualifiedName,
+        Id = testCase.Id,
+        LineNumber = testCase.LineNumber,
+        Source = testCase.Source,
+        AdditionalProperties = testCase.Properties
+          .Where(p => !_ignoredTestCaseProperties.Contains(p.Id))
+          .Select(p => p.Convert(testCase.GetPropertyValue(p)))
+          .ToList()
+      };
+    }
+
+    private static Common.Models.TestProperty Convert(this TestProperty testProperty, object value)
+    {
+      return new Common.Models.TestProperty()
+      {
+        Attributes = testProperty.Attributes.Convert(),
+        Category = testProperty.Category,
+        Description = testProperty.Description,
+        Id = testProperty.Id,
+        Label = testProperty.Label,
+        ValueType = testProperty.ValueType,
+        Value = JsonConvert.SerializeObject(value)
+      };
+    }
+
+    private static TestProperty Convert(this Common.Models.TestProperty testProperty)
+    {
+      var result = TestProperty.Find(testProperty.Id);
+      if (result == null)
+      {
+        var type = GetType(testProperty.ValueType);
+        if (type == null) return null;
+
+        result = TestProperty.Register(testProperty.Id, testProperty.Label, type, testProperty.Attributes.Convert(), typeof(ConversionExtensions));
+        result.Description = testProperty.Description;
+        result.Category = testProperty.Category;
+      }
+      return result;
+    }
+
+    private static Type GetType(string typeName)
+    {
+      Type result;
+      if (_typeCache.TryGetValue(typeName, out result))
+      {
+        return result;
+      }
+      else
+      {
+        _typeCache[typeName] = result = Type.GetType(typeName) ?? Type.GetType(typeName + ", System") ?? Type.GetType(typeName + ", mscorlib");
+        return result;
+      }
+    }
+
+    public static Common.Models.TestPropertyAttributes Convert(this TestPropertyAttributes testPropertyAttributes)
+    {
+      return (Common.Models.TestPropertyAttributes)testPropertyAttributes;
+    }
+
+    public static TestPropertyAttributes Convert(this Common.Models.TestPropertyAttributes testPropertyAttributes)
+    {
+      return (TestPropertyAttributes)testPropertyAttributes;
+    }
+
+    public static TestCase[] Convert(this IEnumerable<Common.Models.TestCase> testCases)
+    {
+      return testCases.Select(Convert).ToArray();
+    }
+
+    public static TestCase Convert(this Common.Models.TestCase testCase)
+    {
+      var result = new TestCase(testCase.FullyQualifiedName, testCase.ExecutorUri, testCase.Source)
+      {
+        CodeFilePath = testCase.CodeFilePath,
+        DisplayName = testCase.DisplayName,
+        ExecutorUri = testCase.ExecutorUri,
+        FullyQualifiedName = testCase.FullyQualifiedName,
+        Id = testCase.Id,
+        LineNumber = testCase.LineNumber
+      };
+
+      foreach (var property in testCase.AdditionalProperties)
+      {
+        var propertyDescription = property.Convert();
+        if (propertyDescription == null) continue;
+        result.SetPropertyValue(propertyDescription, JsonConvert.DeserializeObject(property.Value, GetType(property.ValueType)));
+      }
+
+      return result;
+    }
+
+    public static Common.Models.TestOutcome Convert(this TestOutcome testOutcome)
+    {
+      return (Common.Models.TestOutcome)testOutcome;
+    }
+
+    public static Common.Models.TestResult Convert(this TestResult testResult)
+    {
+      return new Common.Models.TestResult()
+      {
+        ComputerName = testResult.ComputerName,
+        DisplayName = testResult.DisplayName,
+        Duration = testResult.Duration,
+        EndTime = testResult.EndTime,
+        ErrorMessage = testResult.ErrorMessage,
+        ErrorStackTrace = testResult.ErrorStackTrace,
+        Outcome = testResult.Outcome.Convert(),
+        StartTime = testResult.StartTime,
+        TestCase = testResult.TestCase.Convert()
+      };
+    }
+  }
+}

--- a/AxoCover.Runner/ConversionExtensions.cs
+++ b/AxoCover.Runner/ConversionExtensions.cs
@@ -52,7 +52,7 @@ namespace AxoCover.Runner
         Description = testProperty.Description,
         Id = testProperty.Id,
         Label = testProperty.Label,
-        ValueType = testProperty.ValueType,
+        ValueType = value == null ? null : value.GetType().AssemblyQualifiedName,
         Value = JsonConvert.SerializeObject(value)
       };
     }

--- a/AxoCover.Runner/Program.cs
+++ b/AxoCover.Runner/Program.cs
@@ -25,6 +25,10 @@ namespace AxoCover.Runner
     {
       try
       {
+#if DEBUG
+        AppDomain.CurrentDomain.FirstChanceException += (o, e) => Console.WriteLine(e.Exception.GetDescription());
+#endif
+
         RunnerMode runnerMode;
         int parentPid;
 

--- a/AxoCover.Runner/TestDiscoveryContext.cs
+++ b/AxoCover.Runner/TestDiscoveryContext.cs
@@ -38,7 +38,7 @@ namespace AxoCover.Runner
 
     public void SendMessage(TestMessageLevel testMessageLevel, string message)
     {
-      _monitor.RecordMessage(testMessageLevel, message);
+      _monitor.RecordMessage(testMessageLevel.Convert(), message);
     }
   }
 }

--- a/AxoCover.Runner/TestDiscoveryService.cs
+++ b/AxoCover.Runner/TestDiscoveryService.cs
@@ -1,9 +1,8 @@
 ﻿using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
 using AxoCover.Common.Runner;
 using AxoCover.Runner.Settings;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,8 +19,8 @@ namespace AxoCover.Runner
     IncludeExceptionDetailInFaults = true)]
   public class TestDiscoveryService : ITestDiscoveryService
   {
-    private ITestDiscoveryMonitor _monitor;
     private List<ITestDiscoverer> _testDiscoverers = new List<ITestDiscoverer>();
+    private ITestDiscoveryMonitor _monitor;
     private bool _isShuttingDown = false;
 
     public void Initialize()
@@ -112,9 +111,8 @@ namespace AxoCover.Runner
           }
           _monitor.RecordMessage(TestMessageLevel.Informational, $"Discoverer finished.");
         }
-
+        _monitor.RecordResults(context.TestCases.Convert());
         _monitor.RecordMessage(TestMessageLevel.Informational, $"Test discovery finished.");
-        _monitor.RecordResults(context.TestCases);
       }
       catch (Exception e)
       {

--- a/AxoCover.Runner/TestExecutionContext.cs
+++ b/AxoCover.Runner/TestExecutionContext.cs
@@ -142,23 +142,23 @@ namespace AxoCover.Runner
 
     public void RecordEnd(TestCase testCase, TestOutcome outcome)
     {
-      _monitor.RecordEnd(testCase, outcome);
+      _monitor.RecordEnd(testCase.Convert(), outcome.Convert());
     }
 
     public void RecordResult(TestResult testResult)
     {
-      _monitor.RecordResult(testResult);
-      _monitor.RecordMessage(TestMessageLevel.Informational, testResult.Outcome.ToString().PadRight(_outcomeLength) + testResult.TestCase.FullyQualifiedName);
+      _monitor.RecordResult(testResult.Convert());
+      _monitor.RecordMessage(Common.Models.TestMessageLevel.Informational, testResult.Outcome.ToString().PadRight(_outcomeLength) + testResult.TestCase.FullyQualifiedName);
     }
 
     public void RecordStart(TestCase testCase)
     {
-      _monitor.RecordStart(testCase);
+      _monitor.RecordStart(testCase.Convert());
     }
 
     public void SendMessage(TestMessageLevel testMessageLevel, string message)
     {
-      _monitor.RecordMessage(testMessageLevel, message);
+      _monitor.RecordMessage(testMessageLevel.Convert(), message);
     }
   }
 }

--- a/AxoCover.Runner/packages.config
+++ b/AxoCover.Runner/packages.config
@@ -2,5 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net452" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="15.0.0" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/AxoCover.Runner/packages.config
+++ b/AxoCover.Runner/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="15.0.0" targetFramework="net46" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/AxoCover/AxoCover.csproj
+++ b/AxoCover/AxoCover.csproj
@@ -32,7 +32,7 @@
     <AssemblyName>AxoCover</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/AxoCover/AxoCover.csproj
+++ b/AxoCover/AxoCover.csproj
@@ -17,6 +17,7 @@
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -31,7 +32,7 @@
     <AssemblyName>AxoCover</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -159,10 +160,6 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
-      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\VSSDK.Text.11.0.4\lib\net45\Microsoft.VisualStudio.Text.Data.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
@@ -193,9 +190,8 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -212,15 +208,13 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.1.0.1\lib\net45\System.Windows.Interactivity.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/AxoCover/AxoCover.csproj
+++ b/AxoCover/AxoCover.csproj
@@ -294,6 +294,7 @@
     <Compile Include="Models\Data\CoverageReport\TrackedMethod.cs" />
     <Compile Include="Models\Data\CoverageReport\TrackedMethodRef.cs" />
     <Compile Include="Models\Data\OpenCoverOptions.cs" />
+    <Compile Include="Models\Data\TestAdapters.cs" />
     <Compile Include="Models\Data\TestResults.cs" />
     <Compile Include="Models\DiscoveryProcess.cs" />
     <Compile Include="Models\ExecutionProcess.cs" />

--- a/AxoCover/Models/AxoTestRunner.cs
+++ b/AxoCover/Models/AxoTestRunner.cs
@@ -68,7 +68,7 @@ namespace AxoCover.Models
         }
 
         var finishEvent = new ManualResetEvent(false);
-        _executionProcess = ExecutionProcess.Create(hostProcessInfo, _options.TestPlatform);
+        _executionProcess = ExecutionProcess.Create(AdapterExtensions.GetTestPlatformAssemblyPaths(_options.TestAdapterMode), hostProcessInfo, _options.TestPlatform);
         _executionProcess.MessageReceived += (o, e) => OnTestLogAdded(e.Value);
         _executionProcess.TestStarted += (o, e) =>
         {
@@ -113,7 +113,7 @@ namespace AxoCover.Models
 
         var options = new TestExecutionOptions()
         {
-          AdapterSources = AdapterExtensions.GetAdapters(),
+          AdapterSources = AdapterExtensions.GetTestAdapterAssemblyPaths(_options.TestAdapterMode),
           RunSettingsPath = _options.TestSettings,
           ApartmentState = _options.TestApartmentState,
           OutputPath = outputDirectory,

--- a/AxoCover/Models/ContainerProvider.cs
+++ b/AxoCover/Models/ContainerProvider.cs
@@ -1,8 +1,6 @@
 ﻿using AxoCover.Models.Commands;
-using AxoCover.Models.Extensions;
 using AxoCover.Models.TestCaseProcessors;
 using Microsoft.Practices.Unity;
-using System.Reflection;
 
 namespace AxoCover.Models
 {
@@ -15,8 +13,6 @@ namespace AxoCover.Models
       {
         if (_container == null)
         {
-          Assembly.LoadFrom(AdapterExtensions.GetTestPlatformPaths()[0]);
-
           _container = new UnityContainer();
           RegisterTypes();
         }

--- a/AxoCover/Models/Data/TestAdapters.cs
+++ b/AxoCover/Models/Data/TestAdapters.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace AxoCover.Models.Data
+{
+  [Flags]
+  public enum TestAdapterKinds
+  {
+    None = 0,
+    MSTestV1 = 1,
+    MSTestV2 = 2,
+    NUnit = 4,
+    XUnit = 8
+  }
+}

--- a/AxoCover/Models/Data/TestMethod.cs
+++ b/AxoCover/Models/Data/TestMethod.cs
@@ -1,5 +1,5 @@
 ﻿using AxoCover.Common.Extensions;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using AxoCover.Common.Models;
 using System.Linq;
 
 namespace AxoCover.Models.Data

--- a/AxoCover/Models/DiscoveryProcess.cs
+++ b/AxoCover/Models/DiscoveryProcess.cs
@@ -1,10 +1,9 @@
 ﻿using AxoCover.Common.Events;
 using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
 using AxoCover.Common.ProcessHost;
 using AxoCover.Common.Runner;
 using AxoCover.Models.Extensions;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using System;
 using System.Collections.Generic;
 using System.ServiceModel;

--- a/AxoCover/Models/DiscoveryProcess.cs
+++ b/AxoCover/Models/DiscoveryProcess.cs
@@ -19,15 +19,15 @@ namespace AxoCover.Models
     public event EventHandler<EventArgs<string>> MessageReceived;
     public event EventHandler<EventArgs<TestCase[]>> DiscoveryCompleted;
 
-    private DiscoveryProcess() :
-      base(new ServiceProcessInfo(RunnerMode.Discovery, AdapterExtensions.GetTestPlatformPaths()))
+    private DiscoveryProcess(string[] testPlatformAssemblies) :
+      base(new ServiceProcessInfo(RunnerMode.Discovery, testPlatformAssemblies))
     {
       _serviceStartedEvent.WaitOne();
     }
 
-    public static DiscoveryProcess Create()
+    public static DiscoveryProcess Create(string[] testPlatformAssemblies)
     {
-      var discoveryProcess = new DiscoveryProcess();
+      var discoveryProcess = new DiscoveryProcess(testPlatformAssemblies);
 
       if (discoveryProcess._testDiscoveryService == null)
       {
@@ -70,10 +70,9 @@ namespace AxoCover.Models
       DiscoveryCompleted?.Invoke(this, new EventArgs<TestCase[]>(testCases));
     }
 
-    public void DiscoverTestsAsync(IEnumerable<string> testSourcePaths, string runSettingsPath)
+    public void DiscoverTestsAsync(IEnumerable<string> testSourcePaths, string runSettingsPath, string[] testAdapterAssemblies)
     {
-      var adapters = AdapterExtensions.GetAdapters();
-      _testDiscoveryService.DiscoverTestsAsync(adapters, testSourcePaths, runSettingsPath);
+      _testDiscoveryService.DiscoverTestsAsync(testAdapterAssemblies, testSourcePaths, runSettingsPath);
     }
   }
 }

--- a/AxoCover/Models/ExecutionProcess.cs
+++ b/AxoCover/Models/ExecutionProcess.cs
@@ -28,8 +28,8 @@ namespace AxoCover.Models
     public event EventHandler TestsFinished;
     public event EventHandler DebuggerAttached;
 
-    private ExecutionProcess(IHostProcessInfo hostProcess) :
-      base(hostProcess.Embed(new ServiceProcessInfo(RunnerMode.Execution, AdapterExtensions.GetTestPlatformPaths())))
+    private ExecutionProcess(IHostProcessInfo hostProcess, string[] testPlatformAssemblies) :
+      base(hostProcess.Embed(new ServiceProcessInfo(RunnerMode.Execution, testPlatformAssemblies)))
     {
       _reconnectTimer = new Timer(OnReconnect, null, Timeout.Infinite, Timeout.Infinite);
       _serviceStartedEvent.WaitOne();
@@ -48,11 +48,11 @@ namespace AxoCover.Models
       }
     }
 
-    public static ExecutionProcess Create(IHostProcessInfo hostProcess = null, TestPlatform testPlatform = TestPlatform.x86)
+    public static ExecutionProcess Create(string[] testPlatformAssemblies, IHostProcessInfo hostProcess = null, TestPlatform testPlatform = TestPlatform.x86)
     {
       hostProcess = hostProcess.Embed(new PlatformProcessInfo(testPlatform)) as IHostProcessInfo;
 
-      var executionProcess = new ExecutionProcess(hostProcess);
+      var executionProcess = new ExecutionProcess(hostProcess, testPlatformAssemblies);
 
       if (executionProcess._testExecutionService == null)
       {

--- a/AxoCover/Models/ExecutionProcess.cs
+++ b/AxoCover/Models/ExecutionProcess.cs
@@ -1,11 +1,10 @@
 ﻿using AxoCover.Common.Events;
 using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
 using AxoCover.Common.ProcessHost;
 using AxoCover.Common.Runner;
 using AxoCover.Common.Settings;
 using AxoCover.Models.Extensions;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/AxoCover/Models/Extensions/AdapterExtensions.cs
+++ b/AxoCover/Models/Extensions/AdapterExtensions.cs
@@ -1,8 +1,7 @@
-﻿using AxoCover.Models.Data;
+﻿using AxoCover.Common.Models;
+using AxoCover.Models.Data;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -30,7 +29,6 @@ namespace AxoCover.Models.Extensions
 
     private static readonly string[] _testPlatformAssemblies = new string[]
     {
-      @"CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll",
       @"CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll"
     };
 
@@ -79,7 +77,7 @@ namespace AxoCover.Models.Extensions
       }
     }
 
-    public static Data.TestResult ToTestResult(this Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testResult, TestMethod testMethod)
+    public static Data.TestResult ToTestResult(this Common.Models.TestResult testResult, TestMethod testMethod)
     {
       return new Data.TestResult()
       {

--- a/AxoCover/Models/Extensions/ProjectExtensions.cs
+++ b/AxoCover/Models/Extensions/ProjectExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using AxoCover.Common.Extensions;
+using AxoCover.Models.Data;
 using EnvDTE;
 using System;
 using System.Collections.Generic;
@@ -12,12 +13,12 @@ namespace AxoCover.Models.Extensions
 {
   public static class ProjectExtensions
   {
-    private static readonly string[] _unitTestReferences = new[]
+    private static readonly Dictionary<string, TestAdapterKinds> _unitTestReferences = new Dictionary<string, TestAdapterKinds>(StringComparer.OrdinalIgnoreCase)
     {
-      "Microsoft.VisualStudio.QualityTools.UnitTestFramework",
-      "Microsoft.VisualStudio.TestPlatform.TestFramework",
-      "xunit.core",
-      "nunit.framework"
+      { "Microsoft.VisualStudio.QualityTools.UnitTestFramework", TestAdapterKinds.MSTestV1 },
+      { "Microsoft.VisualStudio.TestPlatform.TestFramework", TestAdapterKinds.MSTestV2 },
+      { "xunit.core", TestAdapterKinds.XUnit },
+      { "nunit.framework", TestAdapterKinds.NUnit }
     };
 
     public static IEnumerable<Project> GetProjects(this Solution solution)
@@ -85,16 +86,26 @@ namespace AxoCover.Models.Extensions
         .Where(p => p.Kind == kind);
     }
 
-    public static bool IsDotNetUnitTestProject(this Project project)
+    public static bool IsDotNetUnitTestProject(this Project project, out TestAdapterKinds adapters)
     {
+      adapters = TestAdapterKinds.None;
       var dotNetProject = project.Object as VSProject2;
 
       var isTestProject = false;
       try
       {
-        isTestProject = dotNetProject != null && dotNetProject.References
-          .OfType<Reference>()
-          .Any(p => _unitTestReferences.Contains(p.Name));
+        if (dotNetProject != null)
+        {
+          foreach (Reference reference in dotNetProject.References.OfType<Reference>())
+          {
+            var adapterKind = TestAdapterKinds.None;
+            if (_unitTestReferences.TryGetValue(reference.Name, out adapterKind))
+            {
+              adapters |= adapterKind;
+              isTestProject = true;
+            }
+          }
+        }
       }
       catch { }
 

--- a/AxoCover/Models/IOptions.cs
+++ b/AxoCover/Models/IOptions.cs
@@ -34,6 +34,7 @@ namespace AxoCover.Models
     string TelemetryKey { get; }
     TestApartmentState TestApartmentState { get; set; }
     TestPlatform TestPlatform { get; set; }
+    TestAdapterMode TestAdapterMode { get; set; }
     string TestRunner { get; set; }
     Color UncoveredColor { get; set; }
     bool IsMergingByHash { get; set; }

--- a/AxoCover/Models/Options.cs
+++ b/AxoCover/Models/Options.cs
@@ -36,6 +36,13 @@ namespace AxoCover.Models
       set { Settings.Default.TestApartmentState = value; }
     }
 
+    [JsonConverter(typeof(StringEnumConverter))]
+    public TestAdapterMode TestAdapterMode
+    {
+      get { return Settings.Default.TestAdapterMode; }
+      set { Settings.Default.TestAdapterMode = value; }
+    }
+
     public string TestSettings
     {
       get { return Settings.Default.TestSettings; }

--- a/AxoCover/Models/TestCaseProcessors/ITestCaseProcessor.cs
+++ b/AxoCover/Models/TestCaseProcessors/ITestCaseProcessor.cs
@@ -1,5 +1,5 @@
-﻿using AxoCover.Models.Data;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+﻿using AxoCover.Common.Models;
+using AxoCover.Models.Data;
 
 namespace AxoCover.Models.TestCaseProcessors
 {

--- a/AxoCover/Models/TestCaseProcessors/NUnitTestCaseProcessor.cs
+++ b/AxoCover/Models/TestCaseProcessors/NUnitTestCaseProcessor.cs
@@ -1,7 +1,7 @@
 ﻿using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
 using AxoCover.Models.Data;
 using AxoCover.Models.Extensions;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/AxoCover/Models/TestCaseProcessors/XUnitTestCaseProcessor.cs
+++ b/AxoCover/Models/TestCaseProcessors/XUnitTestCaseProcessor.cs
@@ -1,6 +1,6 @@
 ﻿using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
 using AxoCover.Models.Data;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using System;
 using System.Text.RegularExpressions;
 

--- a/AxoCover/Models/TestProvider.cs
+++ b/AxoCover/Models/TestProvider.cs
@@ -1,10 +1,10 @@
 ﻿using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
 using AxoCover.Models.Data;
 using AxoCover.Models.Extensions;
 using AxoCover.Models.TestCaseProcessors;
 using EnvDTE;
 using Microsoft.Practices.Unity;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/AxoCover/Properties/Settings.Designer.cs
+++ b/AxoCover/Properties/Settings.Designer.cs
@@ -370,5 +370,17 @@ namespace AxoCover.Properties {
                 this["IsSkippingAutoProps"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Standard")]
+        public global::AxoCover.Common.Settings.TestAdapterMode TestAdapterMode {
+            get {
+                return ((global::AxoCover.Common.Settings.TestAdapterMode)(this["TestAdapterMode"]));
+            }
+            set {
+                this["TestAdapterMode"] = value;
+            }
+        }
     }
 }

--- a/AxoCover/Properties/Settings.Designer.cs
+++ b/AxoCover/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AxoCover.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/AxoCover/Properties/Settings.settings
+++ b/AxoCover/Properties/Settings.settings
@@ -92,5 +92,8 @@
     <Setting Name="IsSkippingAutoProps" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="TestAdapterMode" Type="AxoCover.Common.Settings.TestAdapterMode" Scope="User">
+      <Value Profile="(Default)">Standard</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AxoCover/Resources.Designer.cs
+++ b/AxoCover/Resources.Designer.cs
@@ -1060,6 +1060,15 @@ namespace AxoCover {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Adapter mode.
+        /// </summary>
+        public static string TestAdapterMode {
+            get {
+                return ResourceManager.GetString("TestAdapterMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apartment state.
         /// </summary>
         public static string TestApartmentState {

--- a/AxoCover/Resources.resx
+++ b/AxoCover/Resources.resx
@@ -528,4 +528,7 @@
   <data name="TerminalExceptionRestartVisualStudio" xml:space="preserve">
     <value>Restart Visual Studio.</value>
   </data>
+  <data name="TestAdapterMode" xml:space="preserve">
+    <value>Adapter mode</value>
+  </data>
 </root>

--- a/AxoCover/Views/SettingsView.xaml
+++ b/AxoCover/Views/SettingsView.xaml
@@ -218,11 +218,14 @@
         <Grid.RowDefinitions>
           <RowDefinition/>
           <RowDefinition/>
+          <RowDefinition/>
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static res:Resources.TestPlatform}"/>
         <ListBox Grid.Row="0" Grid.Column="1" SelectedValue="{Binding Options.TestPlatform}" />
         <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static res:Resources.TestApartmentState}"/>
         <ListBox Grid.Row="1" Grid.Column="1" SelectedValue="{Binding Options.TestApartmentState}" />
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="{x:Static res:Resources.TestAdapterMode}"/>
+        <ListBox Grid.Row="2" Grid.Column="1" SelectedValue="{Binding Options.TestAdapterMode}" />
       </Grid>
 
       <TextBlock Text="{x:Static res:Resources.RunSettingsDescription}" Style="{StaticResource Description}"/>

--- a/AxoCover/app.config
+++ b/AxoCover/app.config
@@ -1,17 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="AxoCover.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+            <section name="AxoCover.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
         </sectionGroup>
         <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="AxoCover.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+            <section name="AxoCover.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
         </sectionGroup>
     </configSections>
     <userSettings>
         <AxoCover.Properties.Settings>
             <setting name="TestRunner" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="IsShowingLineCoverage" serializeAs="String">
                 <value>True</value>
@@ -20,10 +20,10 @@
                 <value>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</value>
             </setting>
             <setting name="ExcludeFiles" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="ExcludeDirectories" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="Filters" serializeAs="String">
                 <value>+[*]*</value>
@@ -80,13 +80,16 @@
                 <value>STA</value>
             </setting>
             <setting name="TestSettings" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="IsMergingByHash" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="IsSkippingAutoProps" serializeAs="String">
                 <value>True</value>
+            </setting>
+            <setting name="TestAdapterMode" serializeAs="String">
+                <value>Standard</value>
             </setting>
         </AxoCover.Properties.Settings>
     </userSettings>
@@ -109,9 +112,9 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="EnvDTE" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <assemblyIdentity name="EnvDTE" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/AxoCover/app.config
+++ b/AxoCover/app.config
@@ -114,4 +114,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/AxoCover/packages.config
+++ b/AxoCover/packages.config
@@ -2,8 +2,7 @@
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
   <package id="VsixUpdater" version="1.0.28" targetFramework="net45" />
   <package id="VSSDK.CoreUtility" version="11.0.4" targetFramework="net45" />

--- a/AxoCover/source.extension.vsixmanifest
+++ b/AxoCover/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.51" Language="en-US" Publisher="Péter Major" />
+    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.52" Language="en-US" Publisher="Péter Major" />
     <DisplayName>AxoCover</DisplayName>
     <Description xml:space="preserve">Nice and free .Net code coverage support for Visual Studio with OpenCover.</Description>
     <MoreInfo>https://marketplace.visualstudio.com/items?itemName=axodox1.AxoCover</MoreInfo>

--- a/AxoCover/source.extension.vsixmanifest
+++ b/AxoCover/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.50" Language="en-US" Publisher="Péter Major" />
+    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.51" Language="en-US" Publisher="Péter Major" />
     <DisplayName>AxoCover</DisplayName>
     <Description xml:space="preserve">Nice and free .Net code coverage support for Visual Studio with OpenCover.</Description>
     <MoreInfo>https://marketplace.visualstudio.com/items?itemName=axodox1.AxoCover</MoreInfo>


### PR DESCRIPTION
This change adds support to MSTestV2 (finally!), while keeping support for XUnit and NUnit.

Now there are two test adapter modes:
- Integrated: this only uses the integrated test adapter of Visual Studio, which only supports MSTestV1,
- Standard: this uses external test adapters based on the recently open-sourced Microsoft Test Platform, this currently supports: MSTestV2, NUnit and xUnit

The two modes are needed because I ran into a dependency conflict between MSTestV1 and MSTestV2. AxoCover will automatically set the test adapter mode depending on the solution. If there are only MSTestV1 tests, then it uses integrated mode, if there are no MSTestV2 tests then it uses standard mode. Otherwise the user selection decides, which is saved with the per solution settings.