### PR TITLE
Provide better telemetry about test service crashes

### DIFF
--- a/AxoCover.Common/AxoCover.Common.csproj
+++ b/AxoCover.Common/AxoCover.Common.csproj
@@ -40,6 +40,9 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -60,6 +63,7 @@
     <Compile Include="Extensions\GenericExtensions.cs" />
     <Compile Include="Extensions\NetworkingExtensions.cs" />
     <Compile Include="Extensions\ProcessHostExtensions.cs" />
+    <Compile Include="Models\SerializableException.cs" />
     <Compile Include="Models\TestCase.cs" />
     <Compile Include="Models\TestMessageLevel.cs" />
     <Compile Include="Models\TestOutcome.cs" />

--- a/AxoCover.Common/AxoCover.Common.csproj
+++ b/AxoCover.Common/AxoCover.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -110,7 +110,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AxoCover.Common/AxoCover.Common.csproj
+++ b/AxoCover.Common/AxoCover.Common.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Runner\ITestDiscoveryService.cs" />
     <Compile Include="Runner\ITestExecutionService.cs" />
     <Compile Include="Runner\ITestExecutionMonitor.cs" />
+    <Compile Include="Runner\ITestService.cs" />
     <Compile Include="Runner\TestExecutionOptions.cs" />
     <Compile Include="Settings\TestAdapterMode.cs" />
     <Compile Include="Settings\TestApartmentState.cs" />

--- a/AxoCover.Common/Extensions/GenericExtensions.cs
+++ b/AxoCover.Common/Extensions/GenericExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AxoCover.Common.Models;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -44,6 +45,11 @@ namespace AxoCover.Common.Extensions
     }
 
     public static string GetDescription(this Exception exception)
+    {
+      return exception == null ? string.Empty : new SerializableException(exception).GetDescription();
+    }
+
+    public static string GetDescription(this SerializableException exception)
     {
       var text = string.Empty;
       while (exception != null)

--- a/AxoCover.Common/Models/SerializableException.cs
+++ b/AxoCover.Common/Models/SerializableException.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AxoCover.Common.Models
+{
+  public class SerializableException
+  {
+    public string Type { get; set; }
+
+    public string Message { get; set; }
+
+    public string StackTrace { get; set; }
+
+    public SerializableException InnerException { get; set; }
+
+    public SerializableException() { }
+
+    public SerializableException(Exception exception)
+    {
+      if(exception == null)
+      {
+        throw new ArgumentNullException(nameof(exception));
+      }
+
+      Type = exception.GetType().FullName;
+      Message = exception.Message;
+      StackTrace = exception.StackTrace;
+
+      if(exception.InnerException != null)
+      {
+        InnerException = new SerializableException(exception.InnerException);
+      }
+    }
+
+    public static implicit operator SerializableException(Exception exception)
+    {
+      return new SerializableException(exception);
+    }
+  }
+}

--- a/AxoCover.Common/ProcessHost/ServiceProcess.cs
+++ b/AxoCover.Common/ProcessHost/ServiceProcess.cs
@@ -11,7 +11,6 @@ namespace AxoCover.Common.ProcessHost
 {
   public abstract class ServiceProcess : IDisposable
   {
-    public event EventHandler Loaded;
     public event EventHandler Exited;
     public event EventHandler<EventArgs<string>> OutputReceived;
     private const string _serviceStartedMessage = "Service started at: ";

--- a/AxoCover.Common/Runner/ITestDiscoveryService.cs
+++ b/AxoCover.Common/Runner/ITestDiscoveryService.cs
@@ -7,15 +7,9 @@ namespace AxoCover.Common.Runner
   [ServiceContract(
     SessionMode = SessionMode.Required,
     CallbackContract = typeof(ITestDiscoveryMonitor))]
-  public interface ITestDiscoveryService
+  public interface ITestDiscoveryService : ITestService
   {
-    [OperationContract(IsInitiating = true)]
-    void Initialize();
-
     [OperationContract]
     TestCase[] DiscoverTests(string[] adapterSources, IEnumerable<string> testSourcePaths, string runSettingsPath);
-
-    [OperationContract(IsTerminating = true)]
-    void Shutdown();
   }
 }

--- a/AxoCover.Common/Runner/ITestExecutionService.cs
+++ b/AxoCover.Common/Runner/ITestExecutionService.cs
@@ -7,15 +7,9 @@ namespace AxoCover.Common.Runner
   [ServiceContract(
     SessionMode = SessionMode.Required,
     CallbackContract = typeof(ITestExecutionMonitor))]
-  public interface ITestExecutionService
+  public interface ITestExecutionService : ITestService
   {
-    [OperationContract(IsInitiating = true)]
-    int Initialize();
-
     [OperationContract]
     void RunTests(IEnumerable<TestCase> testCases, TestExecutionOptions options);
-
-    [OperationContract(IsTerminating = true)]
-    void Shutdown();
   }
 }

--- a/AxoCover.Common/Runner/ITestService.cs
+++ b/AxoCover.Common/Runner/ITestService.cs
@@ -1,0 +1,14 @@
+﻿using System.ServiceModel;
+
+namespace AxoCover.Common.Runner
+{
+  [ServiceContract]
+  public interface ITestService
+  {
+    [OperationContract(IsInitiating = true)]
+    int Initialize();
+
+    [OperationContract(IsTerminating = true)]
+    void Shutdown();
+  }
+}

--- a/AxoCover.Common/packages.config
+++ b/AxoCover.Common/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
 </packages>

--- a/AxoCover.Common/packages.config
+++ b/AxoCover.Common/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.1.0" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
 </packages>

--- a/AxoCover.Runner/AxoCover.Runner.csproj
+++ b/AxoCover.Runner/AxoCover.Runner.csproj
@@ -37,10 +37,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>

--- a/AxoCover.Runner/AxoCover.Runner.csproj
+++ b/AxoCover.Runner/AxoCover.Runner.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -92,7 +92,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AxoCover.Runner/Program.cs
+++ b/AxoCover.Runner/Program.cs
@@ -1,6 +1,8 @@
 ﻿using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
 using AxoCover.Common.ProcessHost;
 using AxoCover.Common.Runner;
+using Newtonsoft.Json;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -88,8 +90,10 @@ namespace AxoCover.Runner
       }
       catch (Exception e)
       {
-        ServiceProcess.PrintServiceFailed();
-        Console.WriteLine(e.GetDescription());
+        var crashFilePath = Path.GetTempFileName();
+        var crashDetails = JsonConvert.SerializeObject(new SerializableException(e));
+        File.WriteAllText(crashFilePath, crashDetails);
+        ServiceProcess.PrintServiceFailed(crashFilePath);
       }
     }
 

--- a/AxoCover.Runner/TestDiscoveryService.cs
+++ b/AxoCover.Runner/TestDiscoveryService.cs
@@ -5,6 +5,7 @@ using AxoCover.Runner.Settings;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.ServiceModel;
@@ -22,9 +23,10 @@ namespace AxoCover.Runner
     private List<ITestDiscoverer> _testDiscoverers = new List<ITestDiscoverer>();
     private ITestDiscoveryMonitor _monitor;
 
-    public void Initialize()
+    public int Initialize()
     {
       _monitor = OperationContext.Current.GetCallbackChannel<ITestDiscoveryMonitor>();
+      return Process.GetCurrentProcess().Id;
     }
 
     private void LoadDiscoverers(string adapterSource)

--- a/AxoCover.Runner/packages.config
+++ b/AxoCover.Runner/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.1.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
 </packages>

--- a/AxoCover.Runner/packages.config
+++ b/AxoCover.Runner/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />

--- a/AxoCover/AxoCover.csproj
+++ b/AxoCover/AxoCover.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(VisualStudioVersion)' == '15.0'">15.0</MinimumVisualStudioVersion>
     <MinimumVisualStudioVersion Condition="'$(VisualStudioVersion)' == '14.0'">14.0</MinimumVisualStudioVersion>
@@ -344,6 +344,7 @@
     <Compile Include="Models\ITelemetryManager.cs" />
     <Compile Include="Models\IStorageController.cs" />
     <Compile Include="Models\Options.cs" />
+    <Compile Include="Models\RemoteException.cs" />
     <Compile Include="Models\TestCaseProcessors\ITestCaseProcessor.cs" />
     <Compile Include="Models\ITestProvider.cs" />
     <Compile Include="Models\EditorContext.cs" />
@@ -645,7 +646,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\VsixUpdater.1.0.28\build\VsixUpdater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\VsixUpdater.1.0.28\build\VsixUpdater.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <Import Project="..\packages\VsixUpdater.1.0.28\build\VsixUpdater.targets" Condition="Exists('..\packages\VsixUpdater.1.0.28\build\VsixUpdater.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/AxoCover/AxoCover.csproj
+++ b/AxoCover/AxoCover.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Models\StorageController.cs" />
     <Compile Include="Models\TestCaseProcessors\NUnitTestCaseProcessor.cs" />
     <Compile Include="Models\TestCaseProcessors\XUnitTestCaseProcessor.cs" />
+    <Compile Include="Models\TestProcess.cs" />
     <Compile Include="Models\TestProvider.cs" />
     <Compile Include="Models\TestRunner.cs" />
     <Compile Include="Models\MultiplexedTestRunner.cs" />

--- a/AxoCover/Models/AxoTestRunner.cs
+++ b/AxoCover/Models/AxoTestRunner.cs
@@ -18,14 +18,16 @@ namespace AxoCover.Models
     private readonly IEditorContext _editorContext;
     private readonly IStorageController _storageController;
     private readonly IOptions _options;
+    private readonly ITelemetryManager _telemetryManager;
     private readonly TimeSpan _debuggerTimeout = TimeSpan.FromSeconds(10);
     private int _sessionId = 0;
 
-    public AxoTestRunner(IEditorContext editorContext, IStorageController storageController, IOptions options)
+    public AxoTestRunner(IEditorContext editorContext, IStorageController storageController, IOptions options, ITelemetryManager telemetryManager)
     {
       _editorContext = editorContext;
       _storageController = storageController;
       _options = options;
+      _telemetryManager = telemetryManager;
     }
 
     protected override TestReport RunTests(TestItem testItem, bool isCovering, bool isDebugging)
@@ -155,6 +157,11 @@ namespace AxoCover.Models
         {
           return new TestReport(testResults, null);
         }
+      }
+      catch(RemoteException exception) when (exception != null)
+      {
+        _telemetryManager.UploadExceptionAsync(exception.RemoteReason);
+        throw;
       }
       finally
       {

--- a/AxoCover/Models/DiscoveryProcess.cs
+++ b/AxoCover/Models/DiscoveryProcess.cs
@@ -20,16 +20,7 @@ namespace AxoCover.Models
     
     public static DiscoveryProcess Create(string[] testPlatformAssemblies)
     {
-      var discoveryProcess = new DiscoveryProcess(testPlatformAssemblies);
-
-      if (discoveryProcess.TestService == null)
-      {
-        throw new Exception("Could not create service.");
-      }
-      else
-      {
-        return discoveryProcess;
-      }
+      return new DiscoveryProcess(testPlatformAssemblies);
     }
 
     void ITestDiscoveryMonitor.RecordMessage(TestMessageLevel testMessageLevel, string message)

--- a/AxoCover/Models/DiscoveryProcess.cs
+++ b/AxoCover/Models/DiscoveryProcess.cs
@@ -62,7 +62,7 @@ namespace AxoCover.Models
       _serviceStartedEvent.Set();
     }
 
-    protected override void OnServiceFailed()
+    protected override void OnServiceFailed(SerializableException exception)
     {
       _serviceStartedEvent.Set();
     }

--- a/AxoCover/Models/ExecutionProcess.cs
+++ b/AxoCover/Models/ExecutionProcess.cs
@@ -7,18 +7,11 @@ using AxoCover.Common.Settings;
 using AxoCover.Models.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.ServiceModel;
-using System.Threading;
 
 namespace AxoCover.Models
 {
-  public class ExecutionProcess : ServiceProcess, ITestExecutionMonitor
+  public class ExecutionProcess : TestProcess<ITestExecutionService>, ITestExecutionMonitor
   {
-    private readonly ManualResetEvent _serviceStartedEvent = new ManualResetEvent(false);
-    private int _executionProcessId;
-    private ITestExecutionService _testExecutionService;
-
     public event EventHandler<EventArgs<string>> MessageReceived;
     public event EventHandler<EventArgs<TestCase>> TestStarted;
     public event EventHandler<EventArgs<TestCase>> TestEnded;
@@ -26,27 +19,15 @@ namespace AxoCover.Models
     public event EventHandler DebuggerAttached;
 
     private ExecutionProcess(IHostProcessInfo hostProcess, string[] testPlatformAssemblies) :
-      base(hostProcess.Embed(new ServiceProcessInfo(RunnerMode.Execution, testPlatformAssemblies)))
-    {
-      Exited += OnExited;
-      _serviceStartedEvent.WaitOne();
-    }
-
-    private void OnExited(object sender, EventArgs e)
-    {
-      if(_testExecutionService != null)
-      {
-        (_testExecutionService as ICommunicationObject).Abort();
-      }
-    }
-
+      base(hostProcess.Embed(new ServiceProcessInfo(RunnerMode.Execution, testPlatformAssemblies))) { }
+    
     public static ExecutionProcess Create(string[] testPlatformAssemblies, IHostProcessInfo hostProcess = null, TestPlatform testPlatform = TestPlatform.x86)
     {
       hostProcess = hostProcess.Embed(new PlatformProcessInfo(testPlatform)) as IHostProcessInfo;
 
       var executionProcess = new ExecutionProcess(hostProcess, testPlatformAssemblies);
 
-      if (executionProcess._testExecutionService == null)
+      if (executionProcess.TestService == null)
       {
         throw new Exception("Could not create service.");
       }
@@ -55,25 +36,7 @@ namespace AxoCover.Models
         return executionProcess;
       }
     }
-
-    protected override void OnServiceStarted()
-    {
-      ConnectToService(ServiceUri);
-      _serviceStartedEvent.Set();
-    }
-
-    private void ConnectToService(Uri address)
-    {
-      var channelFactory = new DuplexChannelFactory<ITestExecutionService>(this, NetworkingExtensions.GetServiceBinding());
-      _testExecutionService = channelFactory.CreateChannel(new EndpointAddress(address));
-      _executionProcessId = _testExecutionService.Initialize();
-    }
-
-    protected override void OnServiceFailed(SerializableException exception)
-    {
-      _serviceStartedEvent.Set();
-    }
-
+    
     void ITestExecutionMonitor.RecordMessage(TestMessageLevel testMessageLevel, string message)
     {
       var text = testMessageLevel.GetShortName() + " " + message;
@@ -105,28 +68,7 @@ namespace AxoCover.Models
 
     public void RunTests(IEnumerable<TestCase> testCases, TestExecutionOptions options)
     {
-      _testExecutionService.RunTests(testCases, options);
-    }
-
-    public bool TryShutdown()
-    {
-      try
-      {
-        _testExecutionService.Shutdown();
-        return true;
-      }
-      catch
-      {
-        try
-        {
-          Process.GetProcessById(_executionProcessId).KillWithChildren();
-          return true;
-        }
-        catch
-        {
-          return false;
-        }
-      }
+      TestService.RunTests(testCases, options);
     }
   }
 }

--- a/AxoCover/Models/ExecutionProcess.cs
+++ b/AxoCover/Models/ExecutionProcess.cs
@@ -69,7 +69,7 @@ namespace AxoCover.Models
       _executionProcessId = _testExecutionService.Initialize();
     }
 
-    protected override void OnServiceFailed()
+    protected override void OnServiceFailed(SerializableException exception)
     {
       _serviceStartedEvent.Set();
     }

--- a/AxoCover/Models/ExecutionProcess.cs
+++ b/AxoCover/Models/ExecutionProcess.cs
@@ -25,16 +25,7 @@ namespace AxoCover.Models
     {
       hostProcess = hostProcess.Embed(new PlatformProcessInfo(testPlatform)) as IHostProcessInfo;
 
-      var executionProcess = new ExecutionProcess(hostProcess, testPlatformAssemblies);
-
-      if (executionProcess.TestService == null)
-      {
-        throw new Exception("Could not create service.");
-      }
-      else
-      {
-        return executionProcess;
-      }
+      return new ExecutionProcess(hostProcess, testPlatformAssemblies);
     }
     
     void ITestExecutionMonitor.RecordMessage(TestMessageLevel testMessageLevel, string message)

--- a/AxoCover/Models/HockeyClient.cs
+++ b/AxoCover/Models/HockeyClient.cs
@@ -1,4 +1,5 @@
-﻿using AxoCover.Models.Data;
+﻿using AxoCover.Common.Models;
+using AxoCover.Models.Data;
 using AxoCover.Models.Extensions;
 using System;
 using System.Diagnostics;
@@ -54,7 +55,7 @@ namespace AxoCover.Models
       _httpClient.BaseAddress = new Uri(_uriPrefix);
     }
 
-    protected override async Task<bool> UploadExceptionAsync(Exception exception)
+    protected override async Task<bool> UploadExceptionAsync(SerializableException exception)
     {
       using (new InvariantCulture())
       {

--- a/AxoCover/Models/ITelemetryManager.cs
+++ b/AxoCover/Models/ITelemetryManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using AxoCover.Common.Models;
 using System.Threading.Tasks;
 
 namespace AxoCover.Models
@@ -7,6 +7,6 @@ namespace AxoCover.Models
   {
     bool IsTelemetryEnabled { get; set; }
 
-    Task<bool> UploadExceptionAsync(Exception exception, bool force = false);
+    Task<bool> UploadExceptionAsync(SerializableException exception, bool force = false);
   }
 }

--- a/AxoCover/Models/RemoteException.cs
+++ b/AxoCover/Models/RemoteException.cs
@@ -1,0 +1,16 @@
+﻿using AxoCover.Common.Models;
+using System;
+
+namespace AxoCover.Models
+{
+  public class RemoteException : Exception
+  {
+    public SerializableException RemoteReason { get; private set; }
+
+    public RemoteException(string message, SerializableException remoteReason)
+      : base(message)
+    {
+      RemoteReason = remoteReason;
+    }
+  }
+}

--- a/AxoCover/Models/TelemetryManager.cs
+++ b/AxoCover/Models/TelemetryManager.cs
@@ -33,15 +33,10 @@ namespace AxoCover.Models
     private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
     {
       var description = e.Exception.GetDescription();
-      if (description.Contains(nameof(AxoCover)))
+      if (description.Contains(nameof(AxoCover)) && !Debugger.IsAttached)
       {
-        _editorContext.WriteToLog(Resources.ExceptionEncountered);
-        _editorContext.WriteToLog(description);
-        if (!Debugger.IsAttached)
-        {
-          UploadExceptionAsync(e.Exception);
-          e.Handled = true;
-        }
+        UploadExceptionAsync(e.Exception);
+        e.Handled = true;
       }
     }
 
@@ -68,6 +63,9 @@ namespace AxoCover.Models
     {
       if (IsTelemetryEnabled || force)
       {
+        _editorContext.WriteToLog(Resources.ExceptionEncountered);
+        _editorContext.WriteToLog(exception.GetDescription());
+
         return await UploadExceptionAsync(exception);
       }
       else

--- a/AxoCover/Models/TelemetryManager.cs
+++ b/AxoCover/Models/TelemetryManager.cs
@@ -1,4 +1,5 @@
 ﻿using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
 using AxoCover.Views;
 using System;
 using System.Diagnostics;
@@ -61,9 +62,9 @@ namespace AxoCover.Models
       });
     }
 
-    protected abstract Task<bool> UploadExceptionAsync(Exception exception);
+    protected abstract Task<bool> UploadExceptionAsync(SerializableException exception);
 
-    public async Task<bool> UploadExceptionAsync(Exception exception, bool force = false)
+    public async Task<bool> UploadExceptionAsync(SerializableException exception, bool force = false)
     {
       if (IsTelemetryEnabled || force)
       {

--- a/AxoCover/Models/TestProcess.cs
+++ b/AxoCover/Models/TestProcess.cs
@@ -1,0 +1,76 @@
+﻿using AxoCover.Common.Extensions;
+using AxoCover.Common.Models;
+using AxoCover.Common.ProcessHost;
+using AxoCover.Common.Runner;
+using System;
+using System.Diagnostics;
+using System.ServiceModel;
+using System.Threading;
+
+namespace AxoCover.Models
+{
+  public abstract class TestProcess<TServiceInterface> : ServiceProcess
+    where TServiceInterface : class, ITestService
+  {
+    protected TServiceInterface TestService { get; private set; }
+
+    private readonly ManualResetEvent _serviceStartedEvent = new ManualResetEvent(false);    
+
+    private int _serviceProcessId;
+
+    public TestProcess(IProcessInfo processInfo) : base(processInfo)
+    {
+      Exited += OnExited;
+      _serviceStartedEvent.WaitOne();
+    }
+
+    protected override void OnServiceStarted()
+    {
+      var channelFactory = new DuplexChannelFactory<TServiceInterface>(this, NetworkingExtensions.GetServiceBinding());
+      TestService = channelFactory.CreateChannel(new EndpointAddress(ServiceUri));
+      try
+      {
+        _serviceProcessId = TestService.Initialize();
+      }
+      catch
+      {
+        TestService = null;
+      }
+      _serviceStartedEvent.Set();
+    }
+
+    protected override void OnServiceFailed(SerializableException exception)
+    {
+      _serviceStartedEvent.Set();
+    }
+
+    private void OnExited(object sender, EventArgs e)
+    {
+      if (TestService != null)
+      {
+        (TestService as ICommunicationObject).Abort();
+      }
+    }
+
+    public bool TryShutdown()
+    {
+      try
+      {
+        TestService.Shutdown();
+        return true;
+      }
+      catch
+      {
+        try
+        {
+          Process.GetProcessById(_serviceProcessId).KillWithChildren();
+          return true;
+        }
+        catch
+        {
+          return false;
+        }
+      }
+    }
+  }
+}

--- a/AxoCover/Models/TestProcess.cs
+++ b/AxoCover/Models/TestProcess.cs
@@ -18,10 +18,17 @@ namespace AxoCover.Models
 
     private int _serviceProcessId;
 
+    private SerializableException _failReason;
+
     public TestProcess(IProcessInfo processInfo) : base(processInfo)
     {
       Exited += OnExited;
+
       _serviceStartedEvent.WaitOne();
+      if (TestService == null)
+      {
+        throw new RemoteException("Could not create service.", _failReason);
+      }
     }
 
     protected override void OnServiceStarted()
@@ -41,6 +48,7 @@ namespace AxoCover.Models
 
     protected override void OnServiceFailed(SerializableException exception)
     {
+      _failReason = exception;
       _serviceStartedEvent.Set();
     }
 

--- a/AxoCover/changelog.txt
+++ b/AxoCover/changelog.txt
@@ -10,6 +10,7 @@
 - Support one test returning multiple results
 - Prevent debugging while the test runner is busy
 - Fix error that solution related settings fail to save when a temporary solution is used
+- Provide better telemetry about test service crashes
 
 1.1.0
 - AxoCover now uses its own test runner to support multiple test frameworks

--- a/AxoCover/packages.config
+++ b/AxoCover/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.1.0" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
   <package id="VsixUpdater" version="1.0.28" targetFramework="net45" />

--- a/AxoCover/source.extension.vsixmanifest
+++ b/AxoCover/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.68" Language="en-US" Publisher="Péter Major" />
+    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.69" Language="en-US" Publisher="Péter Major" />
     <DisplayName>AxoCover</DisplayName>
     <Description xml:space="preserve">Nice and free .Net code coverage support for Visual Studio with OpenCover.</Description>
     <MoreInfo>https://marketplace.visualstudio.com/items?itemName=axodox1.AxoCover</MoreInfo>


### PR DESCRIPTION
This change extends error reporting to the test runner process, so I can understand better the test service initialization problems in telemetry.