### PR TITLE
Added adapter guard to prevent conflicting versions of test adapters to be loaded

### DIFF
--- a/AxoCover.Dependencies/AxoCover.Dependencies.csproj
+++ b/AxoCover.Dependencies/AxoCover.Dependencies.csproj
@@ -70,6 +70,15 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>OpenCover\x64\%(Filename)%(Extension)</Link>
     </Content>
+    <Content Include="MSTestAdapter\exclude.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="NUnitAdapter\exclude.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="xUnitAdapter\exclude.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\packages\ReportGenerator.*\tools\*.*">
@@ -97,7 +106,7 @@
     <Content Include="..\packages\MSTest.TestFramework.*\lib\net45\*.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>MSTestAdapter\%(Filename)%(Extension)</Link>
-    </Content>    
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\packages\Microsoft.TestPlatform.ObjectModel.*\lib\net35\*.dll">

--- a/AxoCover.Dependencies/MSTestAdapter/exclude.txt
+++ b/AxoCover.Dependencies/MSTestAdapter/exclude.txt
@@ -1,0 +1,1 @@
+﻿Microsoft.VisualStudio.TestPlatform.*.dll

--- a/AxoCover.Dependencies/NUnitAdapter/exclude.txt
+++ b/AxoCover.Dependencies/NUnitAdapter/exclude.txt
@@ -1,0 +1,2 @@
+﻿nunit.engine.*.dll
+NUnit3.TestAdapter.dll

--- a/AxoCover.Dependencies/xUnitAdapter/exclude.txt
+++ b/AxoCover.Dependencies/xUnitAdapter/exclude.txt
@@ -1,0 +1,2 @@
+﻿xunit.runner.*.dll
+xunit.abstractions.dll

--- a/AxoCover/AxoCover.csproj
+++ b/AxoCover/AxoCover.csproj
@@ -288,6 +288,7 @@
     <Compile Include="Converters\SingleItemToCollectionConverter.cs" />
     <Compile Include="Converters\StringEqualityToVisibilityConverter.cs" />
     <Compile Include="LineCoverageAdornment.cs" />
+    <Compile Include="Models\AdapterGuard.cs" />
     <Compile Include="Models\AxoTestRunner.cs" />
     <Compile Include="Models\BrushAndPenContainer.cs" />
     <Compile Include="Models\Commands\TestCommands.cs" />
@@ -301,8 +302,10 @@
     <Compile Include="Models\Data\CoverageReport\FileRef.cs" />
     <Compile Include="Models\Data\CoverageReport\TrackedMethod.cs" />
     <Compile Include="Models\Data\CoverageReport\TrackedMethodRef.cs" />
+    <Compile Include="Models\Data\IReferenceCounter.cs" />
     <Compile Include="Models\Data\ITestResult.cs" />
     <Compile Include="Models\Data\OpenCoverOptions.cs" />
+    <Compile Include="Models\Data\ReferenceCounter.cs" />
     <Compile Include="Models\Data\TestAdapters.cs" />
     <Compile Include="Models\Data\TestResults.cs" />
     <Compile Include="Models\DiscoveryProcess.cs" />
@@ -334,6 +337,7 @@
     <Compile Include="Models\Extensions\InvariantCulture.cs" />
     <Compile Include="Models\Extensions\ReleaseExtensions.cs" />
     <Compile Include="Models\HockeyClient.cs" />
+    <Compile Include="Models\IAdapterGuard.cs" />
     <Compile Include="Models\ICoverageProvider.cs" />
     <Compile Include="Models\IEditorContext.cs" />
     <Compile Include="Models\IMultiplexer.cs" />

--- a/AxoCover/Models/AdapterGuard.cs
+++ b/AxoCover/Models/AdapterGuard.cs
@@ -1,0 +1,137 @@
+﻿using AxoCover.Common.Extensions;
+using AxoCover.Models.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace AxoCover.Models
+{
+  public class AdapterGuard : IAdapterGuard
+  {
+    private const string _excludeFileName = "exclude.txt";
+    private const string _backupFolderName = ".axoCover/backup";
+
+    private readonly IEditorContext _editorContext;
+    private readonly IReferenceCounter _referenceCounter;
+
+    public AdapterGuard(IEditorContext editorContext, IReferenceCounter referenceCounter)
+    {
+      _editorContext = editorContext;
+      _referenceCounter = referenceCounter;
+    }
+
+    public void BackupAdapters(string[] adapters, string[] targetFolders)
+    {
+      try
+      {
+        _editorContext.WriteToLog($"Backing up conflicting files in {_backupFolderName}...");
+
+        var excludeFilters = adapters
+          .Select(p => Path.Combine(Path.GetDirectoryName(p), _excludeFileName))
+          .Where(p => File.Exists(p))
+          .SelectMany(p => File.ReadAllLines(p))
+          .Select(p => "^" + p.Replace(".", "\\.").Replace("*", ".*") + "$")
+          .Select(p => new Regex(p, RegexOptions.IgnoreCase))
+          .ToArray();
+
+        foreach (var targetFolder in targetFolders.Distinct())
+        {
+          try
+          {
+            _editorContext.WriteToLog($"Backing up files from {targetFolder}:");
+            _referenceCounter.Increase(targetFolder);
+
+            var fileNames = Directory
+              .GetFiles(targetFolder)
+              .Select(p => Path.GetFileName(p))
+              .Where(p => excludeFilters.Any(q => q.IsMatch(p)))
+              .ToArray();
+
+            var backupFolder = Path.Combine(targetFolder, _backupFolderName);
+            Directory.CreateDirectory(backupFolder);
+
+            foreach (var fileName in fileNames)
+            {
+              var targetFile = Path.Combine(targetFolder, fileName);
+              var backupFile = Path.Combine(backupFolder, fileName);
+
+              try
+              {
+                File.Move(targetFile, backupFile);
+                _editorContext.WriteToLog($"Backed up {fileName}.");
+              }
+              catch (Exception e)
+              {
+                _editorContext.WriteToLog($"Could not move {fileName}.");
+                _editorContext.WriteToLog(e.GetDescription());
+              }
+            }
+          }
+          catch (Exception e)
+          {
+            _editorContext.WriteToLog($"Could not read {targetFolder}.");
+            _editorContext.WriteToLog(e.GetDescription());
+          }
+        }
+        _editorContext.WriteToLog($"Backup finished.");
+      }
+      catch (Exception e)
+      {
+        _editorContext.WriteToLog($"Backup failed.");
+        _editorContext.WriteToLog(e.GetDescription());
+      }
+    }
+
+    public void RestoreAdapters(string[] targetFolders)
+    {
+      _editorContext.WriteToLog($"Restoring backed up files from {_backupFolderName}...");
+
+      foreach (var targetFolder in targetFolders.Distinct())
+      {
+        try
+        {
+          _editorContext.WriteToLog($"Restoring files to {targetFolder}:");
+
+          if (_referenceCounter.Decrease(targetFolder) > 0)
+          {
+            _editorContext.WriteToLog($"Skipping. {targetFolder} is still in use.");
+            continue;
+          }
+
+          var backupFolder = Path.Combine(targetFolder, _backupFolderName);
+          Directory.CreateDirectory(backupFolder);
+
+          var backupFiles = Directory
+            .GetFiles(backupFolder);
+
+          foreach (var backupFile in backupFiles)
+          {
+            var fileName = Path.GetFileName(backupFile);
+            var targetFile = Path.Combine(targetFolder, fileName);
+
+            try
+            {
+              File.Move(backupFile, targetFile);
+              _editorContext.WriteToLog($"Restored {fileName}.");
+            }
+            catch (Exception e)
+            {
+              _editorContext.WriteToLog($"Could not move {fileName}.");
+              _editorContext.WriteToLog(e.GetDescription());
+            }
+          }
+        }
+        catch (Exception e)
+        {
+          _editorContext.WriteToLog($"Could not read {targetFolder}.");
+          _editorContext.WriteToLog(e.GetDescription());
+        }
+      }
+      _editorContext.WriteToLog($"Restore finished.");
+    }
+  }
+}

--- a/AxoCover/Models/ContainerProvider.cs
+++ b/AxoCover/Models/ContainerProvider.cs
@@ -1,4 +1,5 @@
 ﻿using AxoCover.Models.Commands;
+using AxoCover.Models.Data;
 using AxoCover.Models.TestCaseProcessors;
 using Microsoft.Practices.Unity;
 
@@ -35,9 +36,11 @@ namespace AxoCover.Models
       Container.RegisterType<ITelemetryManager, HockeyClient>(new ContainerControlledLifetimeManager());
       Container.RegisterType<IOptions, Options>(new ContainerControlledLifetimeManager());
       Container.RegisterType<IReleaseManager, ReleaseManager>(new ContainerControlledLifetimeManager());
+      Container.RegisterType<IAdapterGuard, AdapterGuard>(new ContainerControlledLifetimeManager());
       Container.RegisterType<SelectTestCommand>(new ContainerControlledLifetimeManager());
       Container.RegisterType<JumpToTestCommand>(new ContainerControlledLifetimeManager());
       Container.RegisterType<DebugTestCommand>(new ContainerControlledLifetimeManager());
+      Container.RegisterType<IReferenceCounter, ReferenceCounter>();
     }
   }
 }

--- a/AxoCover/Models/Data/IReferenceCounter.cs
+++ b/AxoCover/Models/Data/IReferenceCounter.cs
@@ -1,0 +1,10 @@
+﻿namespace AxoCover.Models.Data
+{
+  public interface IReferenceCounter
+  {
+    int this[string key] { get; }
+
+    int Decrease(string key);
+    int Increase(string key);
+  }
+}

--- a/AxoCover/Models/Data/ReferenceCounter.cs
+++ b/AxoCover/Models/Data/ReferenceCounter.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AxoCover.Models.Data
+{
+  public class ReferenceCounter : IReferenceCounter
+  {
+    private readonly Dictionary<string, int> _referenceDictinary = new Dictionary<string, int>();
+    private readonly object _syncRoot = new object();
+
+    public int this[string key]
+    {
+      get
+      {
+        lock (_syncRoot)
+        {
+          if (_referenceDictinary.TryGetValue(key, out var count))
+          {
+            return count;
+          }
+          else
+          {
+            return 0;
+          }
+        }
+      }
+    }
+
+    public int Increase(string key)
+    {
+      lock (_syncRoot)
+      {
+        if (_referenceDictinary.TryGetValue(key, out var count))
+        {
+          _referenceDictinary[key] = ++count;
+          return count;
+        }
+        else
+        {
+          _referenceDictinary[key] = 1;
+          return 1;
+        }
+      }
+    }
+
+    public int Decrease(string key)
+    {
+      lock (_syncRoot)
+      {
+        if (_referenceDictinary.TryGetValue(key, out var count))
+        {
+          _referenceDictinary[key] = --count;
+
+          if (count == 0)
+          {
+            _referenceDictinary.Remove(key);
+          }
+          return count;
+        }
+        else
+        {
+          return 0;
+        }
+      }
+    }
+  }
+}

--- a/AxoCover/Models/IAdapterGuard.cs
+++ b/AxoCover/Models/IAdapterGuard.cs
@@ -1,0 +1,8 @@
+﻿namespace AxoCover.Models
+{
+  public interface IAdapterGuard
+  {
+    void BackupAdapters(string[] adapters, string[] targetFolders);
+    void RestoreAdapters(string[] targetFolders);
+  }
+}

--- a/AxoCover/changelog.txt
+++ b/AxoCover/changelog.txt
@@ -11,6 +11,7 @@
 - Prevent debugging while the test runner is busy
 - Fix error that solution related settings fail to save when a temporary solution is used
 - Provide better telemetry about test service crashes
+- Added adapter guard to prevent conflicting versions of test adapters to be loaded
 
 1.1.0
 - AxoCover now uses its own test runner to support multiple test frameworks

--- a/AxoCover/source.extension.vsixmanifest
+++ b/AxoCover/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.70" Language="en-US" Publisher="Péter Major" />
+    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.71" Language="en-US" Publisher="Péter Major" />
     <DisplayName>AxoCover</DisplayName>
     <Description xml:space="preserve">Nice and free .Net code coverage support for Visual Studio with OpenCover.</Description>
     <MoreInfo>https://marketplace.visualstudio.com/items?itemName=axodox1.AxoCover</MoreInfo>


### PR DESCRIPTION
This change aims to fix numerous weird issues caused by loading conflicting versions of test related assemblies. The issue is caused by having different versions of test framework DLLs in the test project and AxoCover - for some AxoCover functionality to work properly forked versions of the test adapters are used.

This change backs up the conflicting DLLs in the .axoCover/backup folder of the output directories.