### PR TITLE
Tag merged releases automatically

### DIFF
--- a/AxoCover.ReleaseTagger/App.config
+++ b/AxoCover.ReleaseTagger/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/AxoCover.ReleaseTagger/AxoCover.ReleaseTagger.csproj
+++ b/AxoCover.ReleaseTagger/AxoCover.ReleaseTagger.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8D044DD7-2C7E-4C3B-AE0D-5186287CB7BD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>AxoCover.ReleaseTagger</RootNamespace>
+    <AssemblyName>AxoCover.ReleaseTagger</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Octokit, Version=0.24.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octokit.0.24.0\lib\net45\Octokit.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AxoCover.Common\AxoCover.Common.csproj">
+      <Project>{2ca98ecf-c250-4524-ad43-749b59e60bc1}</Project>
+      <Name>AxoCover.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/AxoCover.ReleaseTagger/AxoCover.ReleaseTagger.csproj
+++ b/AxoCover.ReleaseTagger/AxoCover.ReleaseTagger.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -50,7 +53,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AxoCover.Common\AxoCover.Common.csproj">
@@ -59,4 +64,10 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.1.0\build\Microsoft.Net.Compilers.props'))" />
+  </Target>
 </Project>

--- a/AxoCover.ReleaseTagger/Program.cs
+++ b/AxoCover.ReleaseTagger/Program.cs
@@ -1,0 +1,109 @@
+﻿using AxoCover.Common.Extensions;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace AxoCover.ReleaseTagger
+{
+  class Program
+  {
+    private const string _owner = "axodox";
+    private const string _repository = "AxoTools";
+    private static readonly string[] _mergeTargets = new[] { "master", "release" };
+
+    private static readonly Regex _nameRegex = new Regex(@"^(?<branch>.*?)-(?<version>\d+(?:\.\d+)*)$");
+    private static readonly Regex _propertyRegex = new Regex(@"#(?<name>\w+):""(?<value>(?:[^""]|(?<=\\)"")*)""");
+
+    static void Main(string[] args)
+    {
+      var githubToken = Environment.GetEnvironmentVariable("github_token");
+      if (githubToken == null)
+      {
+        Console.WriteLine("Please set the github_token environment variable.");
+        return;
+      }
+      
+      TagReleases(githubToken);
+    }
+
+    private static void TagReleases(string token)
+    {
+      Console.WriteLine("AxoCover release tagger");
+
+      try
+      {
+        Console.Write("Initializing... ");
+        var githubClient = new GitHubClient(new ProductHeaderValue($"{_owner}.{_repository}"))
+        {
+          Credentials = new Credentials(token)
+        };
+        Console.WriteLine("Done.");
+
+        Console.Write("Collecting release information... ");
+        var releases = githubClient.Repository.Release.GetAll(_owner, _repository).Result;
+        var latestReleases = releases
+          .GroupBy(p => GetBranch(p))
+          .Where(p => !_mergeTargets.Contains(p.Key))
+          .Select(p => p.OrderBy(q => q.CreatedAt).Last())
+          .Where(p => !GetProperties(p).ContainsKey("MergedTo"))
+          .ToArray();
+        Console.WriteLine("Done.");
+
+        Console.Write("Collecting commit information... ");
+        var mergedCommits = _mergeTargets
+          .SelectMany(p => githubClient.Repository.Commit.GetAll(_owner, _repository, new CommitRequest() { Sha = p }).Result.Select(q => new { Branch = p, Commit = q }))
+          .GroupBy(p => p.Commit.Sha)
+          .ToDictionary(p => p.Key, p => p.First().Branch);
+        Console.WriteLine("Done.");
+        
+        foreach (var release in latestReleases)
+        {
+          if (mergedCommits.TryGetValue(release.TargetCommitish, out var branch))
+          {
+            try
+            {
+              Console.Write($"Tagging {release.Name}... ");
+              var releaseUpdate = release.ToUpdate();
+              if (!string.IsNullOrWhiteSpace(releaseUpdate.Body))
+              {
+                releaseUpdate.Body += "\r\n";
+              }
+              releaseUpdate.Body += $"#MergedTo:\"{branch}\"";
+
+              githubClient.Repository.Release.Edit(_owner, _repository, release.Id, releaseUpdate).Wait();
+              Console.WriteLine("Done.");
+            }
+            catch (Exception e)
+            {
+              Console.WriteLine("Failed!");
+              Console.WriteLine(e.GetDescription());
+            }
+          }
+        }
+      }
+      catch(Exception e)
+      {
+        Console.WriteLine("Failed!");
+        Console.WriteLine(e.GetDescription());
+      }
+    }
+
+    private static string GetBranch(Release release)
+    {
+      var nameMatch = _nameRegex.Match(release.Name);
+      return nameMatch.Success ? nameMatch.Groups["branch"].Value : string.Empty;
+    }
+
+    private static Dictionary<string, string> GetProperties(Release release)
+    {
+      return _propertyRegex
+        .Matches(release.Body)
+        .OfType<Match>()
+        .ToDictionary(p => p.Groups["name"].Value, p => p.Groups["value"].Value);
+    }
+  }
+}

--- a/AxoCover.ReleaseTagger/Program.cs
+++ b/AxoCover.ReleaseTagger/Program.cs
@@ -48,7 +48,7 @@ namespace AxoCover.ReleaseTagger
         var latestReleases = releases
           .GroupBy(p => GetBranch(p))
           .Where(p => !_mergeTargets.Contains(p.Key))
-          .Select(p => p.OrderBy(q => q.CreatedAt).Last())
+          .Select(p => p.OrderBy(q => GetVersion(q)).Last())
           .Where(p => !GetProperties(p).ContainsKey("MergedTo"))
           .ToArray();
         Console.WriteLine("Done.");
@@ -96,6 +96,18 @@ namespace AxoCover.ReleaseTagger
     {
       var nameMatch = _nameRegex.Match(release.Name);
       return nameMatch.Success ? nameMatch.Groups["branch"].Value : string.Empty;
+    }
+
+    private static Version GetVersion(Release release)
+    {
+      var nameMatch = _nameRegex.Match(release.Name);
+      var versionString = nameMatch.Success ? nameMatch.Groups["version"].Value : "0";
+      while (versionString.Count(p => p == '.') < 3)
+      {
+        versionString += ".0";
+      }
+
+      return Version.Parse(versionString);
     }
 
     private static Dictionary<string, string> GetProperties(Release release)

--- a/AxoCover.ReleaseTagger/Properties/AssemblyInfo.cs
+++ b/AxoCover.ReleaseTagger/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AxoCover.ReleaseTagger")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AxoCover.ReleaseTagger")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8d044dd7-2c7e-4c3b-ae0d-5186287cb7bd")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/AxoCover.ReleaseTagger/packages.config
+++ b/AxoCover.ReleaseTagger/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Octokit" version="0.24.0" targetFramework="net452" />
+</packages>

--- a/AxoCover.ReleaseTagger/packages.config
+++ b/AxoCover.ReleaseTagger/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Net.Compilers" version="2.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="Octokit" version="0.24.0" targetFramework="net452" />
 </packages>

--- a/AxoCover.sln
+++ b/AxoCover.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AxoCover", "AxoCover\AxoCover.csproj", "{B6D78640-676C-44BF-BCF0-6DB16A424EF8}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -28,6 +28,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		appveyor.yml = appveyor.yml
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AxoCover.ReleaseTagger", "AxoCover.ReleaseTagger\AxoCover.ReleaseTagger.csproj", "{8D044DD7-2C7E-4C3B-AE0D-5186287CB7BD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +61,10 @@ Global
 		{30A4D1CC-28C2-4822-B76A-5131DDD3666E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{30A4D1CC-28C2-4822-B76A-5131DDD3666E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{30A4D1CC-28C2-4822-B76A-5131DDD3666E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D044DD7-2C7E-4C3B-AE0D-5186287CB7BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D044DD7-2C7E-4C3B-AE0D-5186287CB7BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D044DD7-2C7E-4C3B-AE0D-5186287CB7BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D044DD7-2C7E-4C3B-AE0D-5186287CB7BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,9 @@ assembly_info:
   assembly_version: '{version}'
   assembly_file_version: '{version}'
   assembly_informational_version: '{version}'
+environment:
+  github_token:
+    secure: H0Lx0YMzb8x3GAs8ibahv1wE2WoLmWoX26JXcHaGixm/XXQjUWG8bvprcGTN68fN
 before_build:
 - cmd: nuget restore
 build:
@@ -23,3 +26,5 @@ deploy:
     secure: Vak3FzsaGXTJb/S0Ee3fPOWlHPNi52kz2e7WCLhwAa6pNe4jfKjl5rNEFfcnecI8
   artifact: AxoCover.vsix
   prerelease: true
+after_deploy:
+- cmd: AxoCover.ReleaseTagger\bin\Release\AxoCover.ReleaseTagger.exe


### PR DESCRIPTION
This change makes the build automatically tag merged releases, so clients will update to the appropriate branch accordingly.