### PR TITLE
Show console output in test details view

### DIFF
--- a/AxoCover.Common/AxoCover.Common.csproj
+++ b/AxoCover.Common/AxoCover.Common.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Models\TestProperty.cs" />
     <Compile Include="Models\TestPropertyAttributes.cs" />
     <Compile Include="Models\TestResult.cs" />
+    <Compile Include="Models\TestResultMessage.cs" />
     <Compile Include="ProcessHost\IHostProcessInfo.cs" />
     <Compile Include="ProcessHost\IProcessInfo.cs" />
     <Compile Include="ProcessHost\PlatformProcessInfo.cs" />

--- a/AxoCover.Common/Models/TestResult.cs
+++ b/AxoCover.Common/Models/TestResult.cs
@@ -32,5 +32,8 @@ namespace AxoCover.Common.Models
 
     [DataMember]
     public TestCase TestCase { get; set; }
+
+    [DataMember]
+    public TestResultMessage[] Messages { get; set; }
   }
 }

--- a/AxoCover.Common/Models/TestResultMessage.cs
+++ b/AxoCover.Common/Models/TestResultMessage.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AxoCover.Common.Models
+{
+  [DataContract]
+  public class TestResultMessage
+  {
+    [DataMember]
+    public string Category { get; set; }
+
+    [DataMember]
+    public string Text { get; set; }
+  }
+}

--- a/AxoCover.Runner/ConversionExtensions.cs
+++ b/AxoCover.Runner/ConversionExtensions.cs
@@ -140,7 +140,19 @@ namespace AxoCover.Runner
         ErrorStackTrace = testResult.ErrorStackTrace,
         Outcome = testResult.Outcome.Convert(),
         StartTime = testResult.StartTime,
-        TestCase = testResult.TestCase.Convert()
+        TestCase = testResult.TestCase.Convert(),
+        Messages = testResult.Messages
+          .Select(p => p.Convert())
+          .ToArray()
+      };
+    }
+
+    public static Common.Models.TestResultMessage Convert(this TestResultMessage testResult)
+    {
+      return new Common.Models.TestResultMessage()
+      {
+        Category = testResult.Category,
+        Text = testResult.Text
       };
     }
   }

--- a/AxoCover/Controls/Styles.xaml
+++ b/AxoCover/Controls/Styles.xaml
@@ -202,6 +202,15 @@
   <Style TargetType="TextBox">
     <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxTextBrushKey}}"/>
     <Setter Property="CaretBrush" Value="{DynamicResource {x:Static vsui:EnvironmentColors.ComboBoxTextBrushKey}}"/>
+    <Setter Property="ContextMenu">
+      <Setter.Value>
+        <ContextMenu>
+          <MenuItem Header="Cut" Command="Cut"/>
+          <MenuItem Header="Copy" Command="Copy"/>
+          <MenuItem Header="Paste" Command="Paste"/>
+        </ContextMenu>
+      </Setter.Value>
+    </Setter>
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="TextBoxBase">

--- a/AxoCover/Models/AdapterGuard.cs
+++ b/AxoCover/Models/AdapterGuard.cs
@@ -61,6 +61,11 @@ namespace AxoCover.Models
 
               try
               {
+                if(File.Exists(backupFile))
+                {
+                  _editorContext.WriteToLog($"Discarding old backup of {fileName}...");
+                  File.Delete(backupFile);
+                }
                 File.Move(targetFile, backupFile);
                 _editorContext.WriteToLog($"Backed up {fileName}.");
               }
@@ -115,8 +120,11 @@ namespace AxoCover.Models
 
             try
             {
-              File.Move(backupFile, targetFile);
-              _editorContext.WriteToLog($"Restored {fileName}.");
+              if(!File.Exists(targetFile))
+              {
+                File.Move(backupFile, targetFile);
+                _editorContext.WriteToLog($"Restored {fileName}.");
+              }              
             }
             catch (Exception e)
             {

--- a/AxoCover/Models/AxoTestRunner.cs
+++ b/AxoCover/Models/AxoTestRunner.cs
@@ -156,8 +156,7 @@ namespace AxoCover.Models
             OnTestLogAdded(Resources.GeneratingCoverageReport);
           }
         }
-
-
+        
         _executionProcess.WaitForExit();
 
         if (_isAborting) return null;

--- a/AxoCover/Models/Commands/TestCommands.cs
+++ b/AxoCover/Models/Commands/TestCommands.cs
@@ -21,7 +21,7 @@ namespace AxoCover.Models.Commands
       CommandCalled?.Invoke(this, new EventArgs<TestMethod>(parameter as TestMethod));
     }
 
-    protected void OnCanExecuteChanged()
+    public void RefreshCanExecuteChanged()
     {
       CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
@@ -38,8 +38,8 @@ namespace AxoCover.Models.Commands
     public DebugTestCommand(ITestRunner testRunner)
     {
       _testRunner = testRunner;
-      _testRunner.TestsStarted += (o, e) => OnCanExecuteChanged();
-      _testRunner.TestsFinished += (o, e) => OnCanExecuteChanged();
+      _testRunner.TestsStarted += (o, e) => RefreshCanExecuteChanged();
+      _testRunner.TestsFinished += (o, e) => RefreshCanExecuteChanged();
     }
 
     public override bool CanExecute(object parameter)

--- a/AxoCover/Models/Data/TestResult.cs
+++ b/AxoCover/Models/Data/TestResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace AxoCover.Models.Data
 {
@@ -15,5 +16,7 @@ namespace AxoCover.Models.Data
     public StackItem[] StackTrace { get; set; }
 
     public int SessionId { get; set; }
+
+    public string Output { get; set; }
   }
 }

--- a/AxoCover/Models/Extensions/AdapterExtensions.cs
+++ b/AxoCover/Models/Extensions/AdapterExtensions.cs
@@ -115,6 +115,8 @@ namespace AxoCover.Models.Extensions
         Outcome = testResult.Outcome.ToTestState(),
         ErrorMessage = GetShortErrorMessage(testResult.ErrorMessage),
         StackTrace = StackItem.FromStackTrace(testResult.ErrorStackTrace),
+        Output = testResult.Messages.Length > 0 ? 
+          string.Join(Environment.NewLine, testResult.Messages.Select(p => p.Text)).Trim() : null,
         SessionId = sessionId
       };
     }

--- a/AxoCover/Resources.Designer.cs
+++ b/AxoCover/Resources.Designer.cs
@@ -214,6 +214,15 @@ namespace AxoCover {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Console output.
+        /// </summary>
+        public static string ConsoleOutput {
+            get {
+                return ResourceManager.GetString("ConsoleOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cover.
         /// </summary>
         public static string Cover {
@@ -241,7 +250,7 @@ namespace AxoCover {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Run tests to get a coverage report..
+        ///   Looks up a localized string similar to Cover tests to get a coverage report..
         /// </summary>
         public static string CoverageExplorerPlaceholder {
             get {
@@ -408,6 +417,15 @@ namespace AxoCover {
         public static string Error {
             get {
                 return ResourceManager.GetString("Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error message &amp; stack-trace.
+        /// </summary>
+        public static string ErrorMessageAndStackTrace {
+            get {
+                return ResourceManager.GetString("ErrorMessageAndStackTrace", resourceCulture);
             }
         }
         

--- a/AxoCover/Resources.resx
+++ b/AxoCover/Resources.resx
@@ -289,7 +289,7 @@
     <value>Uncovered</value>
   </data>
   <data name="CoverageExplorerPlaceholder" xml:space="preserve">
-    <value>Run tests to get a coverage report.</value>
+    <value>Cover tests to get a coverage report.</value>
   </data>
   <data name="CoverageSearchPlaceholder" xml:space="preserve">
     <value>Search coverage results of methods, classes, namespaces and projects</value>
@@ -602,5 +602,11 @@
   </data>
   <data name="SupportedTestFrameworks" xml:space="preserve">
     <value>Supported test frameworks:</value>
+  </data>
+  <data name="ConsoleOutput" xml:space="preserve">
+    <value>Console output</value>
+  </data>
+  <data name="ErrorMessageAndStackTrace" xml:space="preserve">
+    <value>Error message &amp; stack-trace</value>
   </data>
 </root>

--- a/AxoCover/ViewModels/CodeItemViewModel.cs
+++ b/AxoCover/ViewModels/CodeItemViewModel.cs
@@ -110,8 +110,8 @@ namespace AxoCover.ViewModels
       if (Parent != null)
       {
         Parent.Children.OrderedAdd(this as T, (a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.CodeItem.DisplayName, b.CodeItem.DisplayName));
-        _isExpanded = parent == null;
       }
+      _isExpanded = parent == null;
       Children.CollectionChanged += OnChildrenChanged;
       foreach (var childItem in codeItem.Children)
       {

--- a/AxoCover/ViewModels/TestDetailsViewModel.cs
+++ b/AxoCover/ViewModels/TestDetailsViewModel.cs
@@ -24,6 +24,7 @@ namespace AxoCover.ViewModels
         NotifyPropertyChanged(nameof(IsSelectionValid));
         NotifyPropertyChanged(nameof(IsMethod));
         NotifyPropertyChanged(nameof(IsGroup));
+        DebugTestItemCommand.RefreshCanExecuteChanged();
       }
     }
 
@@ -82,7 +83,7 @@ namespace AxoCover.ViewModels
       }
     }
 
-    public ICommand DebugTestItemCommand => _debugTestCommand;
+    public DebugTestCommand DebugTestItemCommand => _debugTestCommand;
 
     public TestDetailsViewModel(IEditorContext editorContext, DebugTestCommand debugTestCommand)
     {

--- a/AxoCover/ViewModels/TestResultCollectionViewModel.cs
+++ b/AxoCover/ViewModels/TestResultCollectionViewModel.cs
@@ -70,6 +70,8 @@ namespace AxoCover.ViewModels
       NotifyPropertyChanged(nameof(Method));
       NotifyPropertyChanged(nameof(Outcome));
       NotifyPropertyChanged(nameof(StackTrace));
+      NotifyPropertyChanged(nameof(Output));
+      NotifyPropertyChanged(nameof(AreHeadersVisible));
       NotifyPropertyChanged(nameof(IconPath));
     }
 
@@ -126,6 +128,12 @@ namespace AxoCover.ViewModels
     public TestState Outcome => SelectedResult?.Outcome ?? TestState.Scheduled;
 
     public StackItem[] StackTrace => SelectedResult?.StackTrace;
+
+    public string Output => SelectedResult?.Output;
+
+    public bool AreHeadersVisible => 
+      !string.IsNullOrWhiteSpace(SelectedResult?.ErrorMessage) &&
+      !string.IsNullOrWhiteSpace(SelectedResult?.Output);
 
     public string IconPath
     {

--- a/AxoCover/ViewModels/TestSolutionViewModel.cs
+++ b/AxoCover/ViewModels/TestSolutionViewModel.cs
@@ -1,4 +1,6 @@
-﻿using AxoCover.Models.Data;
+﻿using AxoCover.Common.Events;
+using AxoCover.Models.Data;
+using System;
 
 namespace AxoCover.ViewModels
 {
@@ -24,19 +26,19 @@ namespace AxoCover.ViewModels
       NotifyPropertyChanged(nameof(IsEmpty));
     }
 
+    public event EventHandler<EventArgs<TestItemViewModel>> AutoCoverTargetUpdated;
+
     private TestItemViewModel _autoCoverTarget;
     public TestItemViewModel AutoCoverTarget
     {
       get { return _autoCoverTarget; }
       set
       {
-        var oldAutoCoverTarget = _autoCoverTarget;
+        var oldCoverTarget = _autoCoverTarget;
         _autoCoverTarget = value;
+        if(oldCoverTarget != null) AutoCoverTargetUpdated?.Invoke(this, new EventArgs<TestItemViewModel>(oldCoverTarget));
+        if(_autoCoverTarget != null) AutoCoverTargetUpdated?.Invoke(this, new EventArgs<TestItemViewModel>(_autoCoverTarget));
 
-        if (oldAutoCoverTarget != null)
-        {
-          oldAutoCoverTarget.IsCoverOnBuild = false;
-        }
         NotifyPropertyChanged(nameof(AutoCoverTarget));
       }
     }

--- a/AxoCover/Views/TestDetailsView.xaml
+++ b/AxoCover/Views/TestDetailsView.xaml
@@ -46,8 +46,9 @@
       </StackPanel>
       <TextBlock Text="{Binding SelectedItem.CodeItem.Kind}" DockPanel.Dock="Right"
                  Visibility="{Binding IsGroup, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-      <TextBlock TextWrapping="Wrap" VerticalAlignment="Center"
-                 Text="{Binding SelectedItem.CodeItem.DisplayName}"/>
+      <TextBlock TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                 Text="{Binding SelectedItem.CodeItem.DisplayName}"
+                 ToolTip="{Binding SelectedItem.CodeItem.DisplayName}"/>
     </DockPanel>
     <DockPanel Visibility="{Binding IsMethod, Converter={StaticResource BooleanToVisibilityConverter}}">
       <StackPanel HorizontalAlignment="Center" Orientation="Horizontal" DockPanel.Dock="Bottom"
@@ -66,24 +67,40 @@
                                Command="{Binding SelectedItem.Result.NextCommand}"/>
       </StackPanel>
       <ScrollViewer MaxHeight="400" VerticalScrollBarVisibility="Auto"
-                    Visibility="{Binding SelectedItem.Result, Converter={StaticResource NullToVisibilityConverter}}">
-        <StackPanel Visibility="{Binding ErrorMessage, Converter={StaticResource NullToVisibilityConverter}}"
+                    Visibility="{Binding Result, Converter={StaticResource NullToVisibilityConverter}}"
                     DataContext="{Binding SelectedItem.Result}">
-          <TextBox Margin="3" TextWrapping="Wrap" IsReadOnly="True" Background="Transparent" BorderThickness="0"                  
-                   Text="{Binding ErrorMessage, Mode=OneWay}"/>
-          <ItemsControl Margin="3" ItemsSource="{Binding StackTrace}">
-            <ItemsControl.ItemTemplate>
-              <DataTemplate>
-                <controls:ActionButton HorizontalAlignment="Left"
-                                       Text="{Binding Method, StringFormat={x:Static res:Resources.StackItemFormat}}"
-                                       ToolTip="{Binding Method, StringFormat={x:Static res:Resources.StackItemFormat}}"
-                                       IsEnabled="{Binding HasValidFileReference}"
-                                       Tag="{Binding}"
-                                       Command="{Binding DataContext.NavigateToStackItemCommand, Source={x:Reference _root}}"
-                                       CommandParameter="{Binding}"/>
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
+        <StackPanel>
+          <StackPanel Visibility="{Binding Output, Converter={StaticResource NullToVisibilityConverter}}">
+            <TextBlock Text="{x:Static res:Resources.ConsoleOutput}" Margin="3" 
+                       Visibility="{Binding AreHeadersVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Border Background="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}" Margin="3">
+              <TextBox Margin="3" TextWrapping="Wrap" IsReadOnly="True" Background="Transparent" BorderThickness="0"          
+                       Text="{Binding Output, Mode=OneWay}"/>
+            </Border>
+          </StackPanel>
+        
+          <StackPanel Visibility="{Binding ErrorMessage, Converter={StaticResource NullToVisibilityConverter}}">
+            <TextBlock Text="{x:Static res:Resources.ErrorMessageAndStackTrace}" Margin="3" 
+                       Visibility="{Binding AreHeadersVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Border Background="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}" Margin="3">
+              <TextBox Margin="3" TextWrapping="Wrap" IsReadOnly="True" Background="Transparent" BorderThickness="0"                  
+                       Text="{Binding ErrorMessage, Mode=OneWay}"/>
+            </Border>
+            <ItemsControl Margin="3" ItemsSource="{Binding StackTrace}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <Border ToolTip="{Binding Method, StringFormat={x:Static res:Resources.StackItemFormat}}">
+                    <controls:ActionButton HorizontalAlignment="Left"
+                                           Text="{Binding Method, StringFormat={x:Static res:Resources.StackItemFormat}}"
+                                           IsEnabled="{Binding HasValidFileReference}"
+                                           Tag="{Binding}"
+                                           Command="{Binding DataContext.NavigateToStackItemCommand, Source={x:Reference _root}}"
+                                           CommandParameter="{Binding}"/>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </StackPanel>
         </StackPanel>
       </ScrollViewer>
     </DockPanel>

--- a/AxoCover/changelog.txt
+++ b/AxoCover/changelog.txt
@@ -12,6 +12,14 @@
 - Fix error that solution related settings fail to save when a temporary solution is used
 - Provide better telemetry about test service crashes
 - Added adapter guard to prevent conflicting versions of test adapters to be loaded
+- Show console output in test details view
+- Fix debug button mistakenly becoming disabled in some situations
+- Fix styling of textbox context menu
+- Trim long test names in test details view to avoid inelegant layout when the window is narrow
+- Show stack item tooltip even when the item is disabled
+- Discard old backups of adapter guard
+- Fix cover on build status not updating in sync between the items of the test state tabs and the test explorer tree
+- Root nodes are now expanded on default in test and coverage explorer
 
 1.1.0
 - AxoCover now uses its own test runner to support multiple test frameworks

--- a/AxoCover/source.extension.vsixmanifest
+++ b/AxoCover/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.71" Language="en-US" Publisher="Péter Major" />
+    <Identity Id="26901782-38e1-48d4-94e9-557d44db052e" Version="1.1.0.72" Language="en-US" Publisher="Péter Major" />
     <DisplayName>AxoCover</DisplayName>
     <Description xml:space="preserve">Nice and free .Net code coverage support for Visual Studio with OpenCover.</Description>
     <MoreInfo>https://marketplace.visualstudio.com/items?itemName=axodox1.AxoCover</MoreInfo>


### PR DESCRIPTION
- Fix debug button mistakenly becoming disabled in some situations
- Fix styling of textbox context menu
- Trim long test names in test details view to avoid inelegant layout when the window is narrow
- Show stack item tooltip even when the item is disabled
- Discard old backups of adapter guard
- Fix cover on build status not updating in sync between the items of the test state tabs and the test explorer tree
- Root nodes are now expanded on default in test and coverage explorer