### PR TITLE
Fixed breakage when solution has a shared project

### DIFF
--- a/AxoCover/Models/TestProvider.cs
+++ b/AxoCover/Models/TestProvider.cs
@@ -59,7 +59,7 @@ namespace AxoCover.Models
         {
           var assemblyName = project.GetAssemblyName();
 
-          if (assemblyName == null) continue;
+          if (string.IsNullOrWhiteSpace(assemblyName)) continue;
 
           var isTestSource = false;
           var testAdapterNames = new List<string>();


### PR DESCRIPTION
A shared project returns "" as for AssemblyName, which causes the command line parser for OpenCover to fail, resulting in a not so useful "Service failed to start" error message.