### PR TITLE
Fixed breakage when solution has a shared project

### DIFF
--- a/AxoCover/Models/TestProvider.cs
+++ b/AxoCover/Models/TestProvider.cs
@@ -59,7 +59,7 @@ namespace AxoCover.Models
         {
           var assemblyName = project.GetAssemblyName();
 
-          if (assemblyName == null) continue;
+          if (string.IsNullOrWhiteSpace(assemblyName)) continue;
 
           var isTestSource = false;
           var testAdapterNames = new List<string>();


### PR DESCRIPTION
Shared project types return "" for AssemblyName, which breaks the OpenCover command line parser. Results in a "Could not create service." error.