### PR TITLE
Changed .vsixmanifest to support Visual Studio 2019.

### DIFF
--- a/AxoCover/source.extension.vsixmanifest
+++ b/AxoCover/source.extension.vsixmanifest
@@ -13,10 +13,10 @@
   </Metadata>
   <Installation InstalledByMsi="false">
     <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
     <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Ultimate" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -27,6 +27,6 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
I really love this extension, so I am trying to contribute with #188 , following this article: https://blogs.msdn.microsoft.com/visualstudio/2018/09/26/how-to-upgrade-extensions-to-support-visual-studio-2019/

As said there, only changing the .vsixmanifest may work things out. I couldn't test the extension locally because I failed to setup the environment to debug, so if someone could run it prior to accepting, would be greatly appreciated!

Sorry if I did something wrong in regards of the pull request, I'm unexperienced with GitHub.